### PR TITLE
Restructure custom-tabs sections to remove duplication

### DIFF
--- a/src/guide/getting_started.md
+++ b/src/guide/getting_started.md
@@ -15,11 +15,12 @@ Connecting to a node requires a seed (your master key). The seed is a bip39 mnem
 
 Breez SDK is available in several platforms. Follow the [Installing](install.md) page for instructions on how to install on your platform.
 
+## Connecting
+
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
 <section>
 
-## Connecting
 ```rust,ignore
 let mnemonic = Mnemonic::generate_in(Language::English, 12)?;
 let seed = mnemonic.to_seed("");
@@ -49,21 +50,12 @@ let sdk = BreezServices::connect(
     .await?;
 ```
 
-At any point we can fetch our balance from the Greenlight node:
-
-```rust,ignore
-if let Some(node_state) = sdk.node_info()? {
-    let balance_ln = node_state.channels_balance_msat;
-    let balance_onchain = node_state.onchain_balance_msat;
-}
-```
 </section>
+
 <div slot="title">Swift</div>
 <section>
 
-## Connecting
 ```swift
-
 // SDK events listener
 class SDKListener: EventListener {
   func onEvent(e: BreezEvent) {
@@ -89,25 +81,12 @@ do {
 }
 ```
 
-At any point we can fetch our balance from the Greenlight node:
-
-```swift
-do {
-  let nodeInfo = try sdk.nodeInfo()
-  let lnBalance = nodeInfo?.channelsBalanceMsat
-  let onchainBalance = nodeInfo?.onchainBalanceMsat
-} catch {
-  // handle error
-}
-```
-
 </section>
+
 <div slot="title">React Native</div>
 <section>
 
-## Connecting
 ```typescript
-
 // SDK events listener
 addEventListener((type, data) => {
     console.log(`received event ${type}`);
@@ -135,22 +114,11 @@ try {
 }
 ```
 
-At any point we can fetch our balance from the Greenlight node:
-
-```typescript
-try {
-    const nodeInfo = await nodeInfo();
-    const lnBalance = nodeInfo.channelsBalanceMsat;
-    const onchainBalance = nodeInfo.onchainBalanceMsat;
-} catch (error) {
-    console.log(error)
-}
-```
 </section>
+
 <div slot="title">Dart</div>
 <section>
 
-## Connecting
 ```dart
 // SDK events listener
 breezEventsStream().listen((event) {
@@ -178,22 +146,11 @@ try {
    // handle error
 }
 ```
-At any point we can fetch our balance from the Greenlight node:
-
-```dart
-try {
-    NodeState? nodeInfo = await nodeInfo();    
-    int lnBalance = nodeInfo?.channelsBalanceMsat;
-    int onchainBalance = nodeInfo?.onchainBalanceMsat;
-} catch (error) {
-    // handle error
-}
-```
 </section>
+
 <div slot="title">Python</div>
 <section>
 
-## Connecting
 ```python
 # SDK events listener
 class SDKListener(breez_sdk.EventListener):
@@ -215,22 +172,11 @@ try:
 except Exception as error:
     # Handle error
 ```
-
-At any point we can fetch our balance from the Greenlight node:
-
-```python
-try: 
-    node_info = node_info()
-    ln_balance = node_info.channels_balance_msat
-    onchain_balance = node_info.onchain_balance_msat
-except Exception as error:
-    # Handle error
-```
 </section>
+
 <div slot="title">Go</div>
 <section>
 
-## Connecting
 ```go
 // SDK events listener
 type BreezListener struct{}
@@ -268,19 +214,11 @@ if err != nil {
     log.Fatalf("Connect failed: %#v", err)
 }
 ```
-At any point we can fetch our balance from the Greenlight node:
-
-```go
-if nodeInfo, err := sdkServices.NodeInfo(); err != nil {
-    lnBalance := nodeInfo.ChannelsBalanceMsat
-    onchainBalance := nodeInfo.OnchainBalanceMsat
-}
-```
 </section>
+
 <div slot="title">C#</div>
 <section>
 
-## Connecting
 ```cs
 using Breez.Sdk;
 
@@ -319,7 +257,91 @@ class SdkListener : EventListener
     }
 }
 ```
+</section>
+</custom-tabs>
+
 At any point we can fetch our balance from the Greenlight node:
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+if let Some(node_state) = sdk.node_info()? {
+    let balance_ln = node_state.channels_balance_msat;
+    let balance_onchain = node_state.onchain_balance_msat;
+}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift
+do {
+  let nodeInfo = try sdk.nodeInfo()
+  let lnBalance = nodeInfo?.channelsBalanceMsat
+  let onchainBalance = nodeInfo?.onchainBalanceMsat
+} catch {
+  // handle error
+}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+try {
+    const nodeInfo = await nodeInfo();
+    const lnBalance = nodeInfo.channelsBalanceMsat;
+    const onchainBalance = nodeInfo.onchainBalanceMsat;
+} catch (error) {
+    console.log(error)
+}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart
+try {
+    NodeState? nodeInfo = await nodeInfo();    
+    int lnBalance = nodeInfo?.channelsBalanceMsat;
+    int onchainBalance = nodeInfo?.onchainBalanceMsat;
+} catch (error) {
+    // handle error
+}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python
+try: 
+    node_info = node_info()
+    ln_balance = node_info.channels_balance_msat
+    onchain_balance = node_info.onchain_balance_msat
+except Exception as error:
+    # Handle error
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go
+if nodeInfo, err := sdkServices.NodeInfo(); err != nil {
+    lnBalance := nodeInfo.ChannelsBalanceMsat
+    onchainBalance := nodeInfo.OnchainBalanceMsat
+}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
 
 ```cs
 try 
@@ -331,7 +353,6 @@ try
 catch (Exception) {
     // Handle error
 }
-
 ```
 </section>
 </custom-tabs>


### PR DESCRIPTION
Experimental attempt to remove text duplication.

Before, a page with multiple text instructions and code snippets would look like this:

```
<custom-tabs category="lang">

  <div slot="title">Language A</div>
  <section>
    Text instruction 1
    // code snippet 1 language A
  </section>

  <div slot="title">Language B</div>
  <section>
    Text instruction 1 (redundant copy)
    // code snippet 1 language B
  </section>

</custom-tabs>

<custom-tabs category="lang">

  <div slot="title">Language A</div>
  <section>
    Text instruction 2
    // code snippet 2 language A
  </section>

  <div slot="title">Language B</div>
  <section>
    Text instruction 2 (redundant copy)
    // code snippet 2 language B
  </section>

</custom-tabs>
```

Note that the text instruction, which introduces the code snippet, would be copy-pasted within each language `<section>` block, leading to redundant copies.

New layout after this PR:


```
Text instruction 1

<custom-tabs category="lang">

  <div slot="title">Language A</div>
  <section>
    // code snippet 1 language A
  </section>

  <div slot="title">Language B</div>
  <section>
    // code snippet 1 language B
  </section>

</custom-tabs>

Text instruction 2

<custom-tabs category="lang">

  <div slot="title">Language A</div>
  <section>
    // code snippet 2 language A
  </section>

  <div slot="title">Language B</div>
  <section>
    // code snippet 2 language B
  </section>

</custom-tabs>
```

Note the text instructions are taken out of and placed above the `<custom-tabs>`.

---

@yaslama is this approach ok?

If yes, I will extend to the other files too (only did `getting_started.md` in this PR).

If not, no problem, I can abandon this PR and we can stick to the previous style.