### PR TITLE
update python and swift example

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -5,9 +5,10 @@
 - [Installing](guide/install.md)
 - [Getting Started](guide/getting_started.md)
 - [Lightning payments](guide/payments.md)
+- [Connecting to an LSP](guide/connecting_lsp.md)
 - [Receiving an on-chain transaction](guide/receive_onchain.md)
 - [Sending an on-chain transaction](guide/send_onchain.md)
-- [Connecting to an LSP](guide/connecting_lsp.md)
+
 - [Using LNURL](guide/lnurl.md)
   - [LNURL-Pay](guide/lnurl_pay.md)
   - [LNURL-Withdraw](guide/lnurl_withdraw.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,3 +14,4 @@
   - [LNURL-Withdraw](guide/lnurl_withdraw.md)
   - [LNURL-Auth](guide/lnurl_auth.md)
 - [Supporting fiat currencies](guide/fiat_currencies.md)
+- [Buy Bitcoin](guide/buy_btc.md)

--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -1,44 +1,84 @@
 # Buy Bitcoin
 
+This section of the Breez SDK documentation provides an example on purchasing Bitcoin using Moonpay as the provider. The example code snippet demonstrates how to initiate a Bitcoin purchase transaction using the Breez SDK.
+
 <custom-tabs category="lang">
 
 <div slot="title">Rust</div>
 <section>
-TODO add docs
+
+```rust
+// TODO add docs
+```
+
 </section>
 
 <div slot="title">Swift</div>
 <section>
-TODO add docs
+
+```swift
+do {
+  let buyBitcoinResponse = try sdk.buyBitcoin(
+    req: BuyBitcoinRequest(provider: .moonpay))
+} catch {
+  // handle error
+}
+    
+```
 </section>
 
 <div slot="title">Android</div>
 <section>
-TODO add docs
+
+```kotlin
+// TODO add docs
+```
 </section>
 
 <div slot="title">React Native</div>
 <section>
-TODO add docs
+
+```typescript
+// TODO add docs
+```
+
 </section>
 
 <div slot="title">Dart</div>
 <section>
-TODO add docs
+
+```dart
+// TODO add docs
+```
 </section>
 
 <div slot="title">Python</div>
 <section>
-TODO add docs
+
+```python
+try:
+    buy_bitcoin_resp = sdk_services.buy_bitcoin(
+        breez_sdk.BuyBitcoinRequest(
+            breez_sdk.BuyBitcoinProvider.MOONPAY))
+except Exception as error:
+    # Handle error
+```
 </section>
 
 <div slot="title">Go</div>
 <section>
-TODO add docs
+
+```go
+// TODO add docs
+```
+
 </section>
 
 <div slot="title">C#</div>
 
 <section>
-TODO add docs
+
+```cs
+// TODO add docs
+```
 </section>

--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -51,7 +51,15 @@ try {
 <section>
 
 ```dart
-// TODO add docs
+try {
+    BuyBitcoinResponse buyBitcoinResponse = buyBitcoin(
+        reqData: BuyBitcoinRequest(provider: BuyBitcoinProvider.Moonpay,
+        ),
+    ); 
+} catch {
+    // Handle error
+}
+
 ```
 </section>
 

--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -1,0 +1,44 @@
+# Buy Bitcoin
+
+<custom-tabs category="lang">
+
+<div slot="title">Rust</div>
+<section>
+TODO add docs
+</section>
+
+<div slot="title">Swift</div>
+<section>
+TODO add docs
+</section>
+
+<div slot="title">Android</div>
+<section>
+TODO add docs
+</section>
+
+<div slot="title">React Native</div>
+<section>
+TODO add docs
+</section>
+
+<div slot="title">Dart</div>
+<section>
+TODO add docs
+</section>
+
+<div slot="title">Python</div>
+<section>
+TODO add docs
+</section>
+
+<div slot="title">Go</div>
+<section>
+TODO add docs
+</section>
+
+<div slot="title">C#</div>
+
+<section>
+TODO add docs
+</section>

--- a/src/guide/connecting_lsp.md
+++ b/src/guide/connecting_lsp.md
@@ -23,7 +23,7 @@ do {
 try {
     val lspId = sdk.lspId()
     if (lspId != null) {
-        val lspInfo = sdk.fetchLspInfo(lspId)
+        val lspInfo = sdk.lspInfo()
     } else {
         // Handle no lsp id scenario
     }
@@ -39,7 +39,7 @@ try {
 ```typescript
 try {
     const lspId = await lspId() 
-    const lspInfo = await fetchLspInfo(lspId)
+    const lspInfo = await lspInfo()
 } catch (error) {
     console.log(error)
 }
@@ -80,7 +80,7 @@ lspId, err := sdkServices.LspId()
 if err != nil {
     // Handle error
 }
-lspInfo, err := sdkServices.FetchLspInfo(*lspId)
+lspInfo, err := sdkServices.LspInfo()
 if err != nil {
     // Handle error
 }
@@ -94,7 +94,7 @@ if err != nil {
 try 
 {
     var lspId = sdk.LspId();
-    var lspInfo = sdk.FetchLspInfo(lspId!);
+    var lspInfo = sdk.LspInfo();
 } 
 catch (Exception) 
 {
@@ -202,7 +202,7 @@ which describes how these channel opening fees are handled.
 
 For the client, the key points are:
 
-* The `LsInformation` can be fetched at any point and includes a list of channel opening fees and the duration for which
+* The `LspInformation` can be fetched at any point and includes a list of channel opening fees and the duration for which
   they are valid. The fees are sorted from cheapest to most expensive. The higher fees are typically also valid for longer.
 * Depending on the application and use-case, the client may choose an appropriate fee and give it as an argument in the
   relevant Breez SDK method. If this fee argument is not provided, Breez SDK will choose an appropriate one instead.

--- a/src/guide/connecting_lsp.md
+++ b/src/guide/connecting_lsp.md
@@ -9,7 +9,7 @@ Based on the API key provided to the Breez SDK, a default LSP is selected for yo
 ```swift
 do {
     let lspId = try sdk.lspId() 
-    let lspInfo = try sdk.fetchLspInfo(lspId: lspId!)
+    let lspInfo = try sdk.lspInfo()
 } catch {
     // Handle error
 }
@@ -65,7 +65,7 @@ try {
 ```python 
 try: 
     lsp_id = sdk_services.lsp_id()
-    lsp_info = sdk_services.fetch_lsp_info(lsp_id)
+    lsp_info = sdk_services.lsp_info()
    
 except Exception as error:
     # Handle error

--- a/src/guide/payments.md
+++ b/src/guide/payments.md
@@ -18,8 +18,9 @@ let invoice = sdk.receive_payment(3000, "Invoice for 3000 sats".into()).await?;
 <section>
 
 ```swift
+let reqData = ReceivePaymentRequest(amountSats: 3000, description: "Invoice for 3000 sats")
 do {
-  let invoice = try sdk.receivePayment(amountSats: 3000, description: "Invoice for 3000 sats")
+  let invoice = try sdk.receivePayment(reqData: reqData )
 } catch {
     // handle error
 }
@@ -68,7 +69,8 @@ try {
 
 ```python
 try:
-  invoice = sdk_services.receive_payment(3000, "Invoice for 3000 sats")
+  req_data = breez_sdk.ReceivePaymentRequest(amount_sats=3000, description="Invoice for 3000 sats")
+  receive_payment_response = sdk_services.receive_payment(req_data=req_data)
 except Exception as error:
   # Handle error
 ```
@@ -116,7 +118,9 @@ sdk.send_payment(bolt11.into(), Some(3000)).await?;
 ```swift
 let bolt11 = "...";
 do {
-  let payment = try sdk.sendPayment(bolt11: bolt11, amountSats: 3000)
+  // The `amountSats` param is optional so nil can be passed if the 
+  // bolt11 invoice spesifies an amount.
+  let payment = try sdk.sendPayment(bolt11:  bolt11, amountSats: 3000)
 } catch {
     // handle error
 }
@@ -171,7 +175,7 @@ try {
 ```python
 bolt11 = "..."
 try:
-  sdk_services.send_payment(bolt11, 3000)
+  sdk_services.send_payment(bolt11=bolt11, amount_sats=3000)
 except Exception as error:
   # Handle error
 ```
@@ -274,9 +278,9 @@ try {
 <section>
 
 ```python
-let node_id = "..."
+node_id = "..."
 try:
-  sdk_services.send_spontaneous_payment(node_id, 3000)
+  sdk_services.send_spontaneous_payment(node_id=node_id, amount_sats=3000)
 except Exception as error:
   # Handle error
 ```

--- a/src/guide/payments.md
+++ b/src/guide/payments.md
@@ -18,9 +18,11 @@ let invoice = sdk.receive_payment(3000, "Invoice for 3000 sats".into()).await?;
 <section>
 
 ```swift
-let reqData = ReceivePaymentRequest(amountSats: 3000, description: "Invoice for 3000 sats")
 do {
-  let invoice = try sdk.receivePayment(reqData: reqData )
+  let invoice = try sdk.receivePayment(
+    reqData: ReceivePaymentRequest(
+        amountSats: 3000, 
+        description: "Invoice for 3000 sats"))
 } catch {
     // handle error
 }
@@ -69,8 +71,10 @@ try {
 
 ```python
 try:
-  req_data = breez_sdk.ReceivePaymentRequest(amount_sats=3000, description="Invoice for 3000 sats")
-  receive_payment_response = sdk_services.receive_payment(req_data=req_data)
+  receive_payment_response = sdk_services.receive_payment(
+    breez_sdk.ReceivePaymentRequest(
+        amount_sats=3000,
+        description="Invoice for 3000 sats"))
 except Exception as error:
   # Handle error
 ```
@@ -175,7 +179,9 @@ try {
 ```python
 bolt11 = "..."
 try:
-  sdk_services.send_payment(bolt11=bolt11, amount_sats=3000)
+  # The `amountSats` param is optional so None can be passed if the 
+  # bolt11 invoice spesifies an amount.
+  sdk_services.send_payment(bolt11=bolt11, amount_sats=None)
 except Exception as error:
   # Handle error
 ```

--- a/src/guide/payments.md
+++ b/src/guide/payments.md
@@ -61,8 +61,12 @@ try {
 
 ```dart
 try {
-    ReceivePaymentRequestData requestData = ReceivePaymentRequestData(amountSats: 3000, description: "Invoice for 3000 sats");
-    ReceivePaymentResponse invoice = await receivePayment(reqData: requestData);
+    ReceivePaymentResponse invoice = await receivePayment(
+        reqData: ReceivePaymentRequestData(
+            amountSats: 3000, 
+            description: "Invoice for 3000 sats",
+            ),
+        );
 } catch (error) {
     // handle error
 }

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -69,11 +69,7 @@ try {
 
 ```dart
 try {
-    // Optional user-selected dynamic fees (see Connecting to LSP section for details)
-    OpeningFeeParams? openingFeeParams = null;
-    ReceiveOnchainRequest request = new ReceiveOnchainRequest(openingFeeParams);
-    
-    SwapInfo swapInfo = await receiveOnchain(request);
+    SwapInfo swapInfo = await receiveOnchain(ReceiveOnchainRequest());
 
     // Send your funds to the below bitcoin address
     String address = swapInfo.bitcoinAddress;

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -3,6 +3,7 @@ There are cases when you have funds in some bitcoin address and you would like t
 
 In such cases, the SDK might have to open a new channel, for which case you can specify an optional user-selected
 channel opening fee[^1]. For simplicity, the examples below use the cheapest fee available.
+In order to receive funds you first have to be connected to an [LSP](connecting_lsp.md).
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
@@ -24,11 +25,9 @@ let address = swap_info.bitcoin_address;
 
 ```swift
 do {
-  // Optional user-selected dynamic fees (see Connecting to LSP section for details)
-  let opening_fee_params = nil;
-  let request = ReceiveOnchainRequest(opening_fee_params: opening_fee_params);
-
-  let swapInfo = try sdk.receiveOnchain(req: request)
+  let openingFeeParams:OpeningFeeParams? = nil
+  let req = ReceiveOnchainRequest(openingFeeParams: openingFeeParams)
+  let swapInfo = try sdk.receiveOnchain(req: req)
 
   // Send your funds to the bellow bitcoin address
   let address = swapInfo.bitcoinAddress;
@@ -95,12 +94,9 @@ try {
 
 ```python
 try: 
-    # Optional user-selected dynamic fees (see Connecting to LSP section for details)
-    opening_fee_params = None
-    request = ReceiveOnchainRequest(opening_fee_params=opening_fee_params)
-
-    swap_info = sdk_services.receive_onchain(req=request)
+    opening_fee_param = lsp_info.opening_fee_params_list.values[0]
     
+    swap_info = sdk_services.receive_onchain(opening_fee_params=opening_fee_param)
     # Send your funds to the below bitcoin address
     address = sdk_services.swap_info.bitcoin_address
 except Exception as error:
@@ -362,9 +358,9 @@ let satPerVbyte = <refund tx fee rate>
 
 do {
   try sdk.refund(
-   swapAddress: "",
-   toAddress: destinationAddress,
-   satPerVbyte: satPerVbyte)
+      swapAddress: refundable?.bitcoinAddress, 
+      toAddress: "...", 
+      satPerVbyte: satPerVbyte)
 } catch {
     // handle error
 }
@@ -426,7 +422,7 @@ destination_address = "..."
 sat_per_vbyte = <refund tx fee rate>
 
 try:
-    sdk_services.refund(refundable.bitcoin_address, destination_address, sat_per_vbyte)
+    result = sdk_services.refund(swap_address=refundable.bitcoin_address, to_address=to_address, sat_per_vbyte=sat_per_vbyte)
 except Exception as error:
     # Handle error
 ```

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -25,9 +25,7 @@ let address = swap_info.bitcoin_address;
 
 ```swift
 do {
-  let openingFeeParams:OpeningFeeParams? = nil
-  let req = ReceiveOnchainRequest(openingFeeParams: openingFeeParams)
-  let swapInfo = try sdk.receiveOnchain(req: req)
+  let swapInfo = try sdk.receiveOnchain(req: ReceiveOnchainRequest())
 
   // Send your funds to the bellow bitcoin address
   let address = swapInfo.bitcoinAddress;
@@ -94,9 +92,8 @@ try {
 
 ```python
 try: 
-    opening_fee_param = lsp_info.opening_fee_params_list.values[0]
-    
-    swap_info = sdk_services.receive_onchain(opening_fee_params=opening_fee_param)
+    swap_info = sdk_services.receive_onchain(breez_sdk.ReceiveOnchainRequest())
+
     # Send your funds to the below bitcoin address
     address = sdk_services.swap_info.bitcoin_address
 except Exception as error:
@@ -422,7 +419,10 @@ destination_address = "..."
 sat_per_vbyte = <refund tx fee rate>
 
 try:
-    result = sdk_services.refund(swap_address=refundable.bitcoin_address, to_address=to_address, sat_per_vbyte=sat_per_vbyte)
+    result = sdk_services.refund(
+        swap_address=refundable.bitcoin_address,
+        to_address=to_address,
+        sat_per_vbyte=sat_per_vbyte)
 except Exception as error:
     # Handle error
 ```

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -11,9 +11,8 @@ First, fetch the current reverse swap fees:
 ```rust,ignore
 let current_fees = sdk.fetch_reverse_swap_fees().await?;
 
-info!("Percentage fee for the reverse swap service: {}", current_fees.fees_percentage);
-info!("Estimated miner fees in sats for locking up funds: {}", current_fees.fees_lockup);
-info!("Estimated miner fees in sats for claiming funds: {}", current_fees.fees_claim);
+info!("Total estimated fees for reverse swap: {}", current_fees.total_estimated_fees);
+
 ```
 </section>
 
@@ -21,14 +20,13 @@ info!("Estimated miner fees in sats for claiming funds: {}", current_fees.fees_c
 <section>
 
 ```swift
-let sendAmountSat:UInt64 = 1_000_000
+// Optional parameter.      
+let sendAmountSat:UInt64? = nil
 try {
  let currentFees = try sdk.fetchReverseSwapFees(
       req: ReverseSwapFeesRequest(sendAmountSat: sendAmountSat))
-  print("Percentage fee for the reverse swap service: \(currentFees.feesPercentage)")
-  print("Estimated miner fees in sats for locking up funds: \(currentFees.feesLockup)")
-  print("Estimated miner fees in sats for claiming funds: \(currentFees.feesClaim)")
-  print("In order to verify that the fetched fee hasn't changed we pass the fee hash: \(currentFees.feesHash)")
+  print("Total estimated fees for reverse swap: \(currentFees.totalEstimatedFees)")
+  
 } catch {
     // handle error
 }
@@ -41,9 +39,7 @@ try {
 ```kotlin
 try {
     val fees = sdk.fetchReverseSwapFees()
-    Log.v("Breez", "Percentage fee for the reverse swap service: ${fees.feesPercentage}")
-    Log.v("Breez", "Estimated miner fees in sats for locking up funds: ${fees.feesLockup}")
-    Log.v("Breez", "Estimated miner fees in sats for claiming funds: ${fees.feesClaim}")
+    Log.v("Breez", "Total estimated fees for reverse swap: ${fees.totalEstimatedFees}")
 } catch (e: Exception) {
     // handle error
 }
@@ -57,9 +53,8 @@ try {
 try {
     const currentFees = await fetchReverseSwapFees()
 
-    console.log(`Percentage fee for the reverse swap service: ${currentFees.feesPercentage}`);
-    console.log(`Estimated miner fees in sats for locking up funds: ${currentFees.feesLockup}`);
-    console.log(`Estimated miner fees in sats for claiming funds: ${currentFees.feesClaim}`);
+    console.log(`Total estimated fees for reverse swap: ${currentFees.totalEstimatedFees}`);
+    
 } catch (error) {
     console.log(error)
 }
@@ -73,9 +68,8 @@ try {
 try {
     ReverseSwapPairInfo currentFees = await fetchReverseSwapFees();
 
-    print(`Percentage fee for the reverse swap service: ${currentFees.feesPercentage}`);
-    print(`Estimated miner fees in sats for locking up funds: ${currentFees.feesLockup}`);
-    print(`Estimated miner fees in sats for claiming funds: ${currentFees.feesClaim}`);
+    print(`Total estimated fees for reverse swap: ${currentFees.totalEstimatedFees}`);
+    
 } catch (error) {
     // handle error
 }
@@ -86,13 +80,11 @@ try {
 <section>
 
 ```python
-send_amount_sat = 1000000
 try: 
-  current_fees = sdk_services.fetch_reverse_swap_fees(breez_sdk.ReverseSwapFeesRequest(send_amount_sat=send_amount_sat))
-  print("Percentage fee for the reverse swap service:", current_fees.fees_percentage)
-  print("Estimated miner fees in sats for locking up funds:", current_fees.fees_lockup)
-  print("Estimated miner fees in sats for claiming funds:", current_fees.fees_claim)
-  print("In order to verify that the fetched fee hasn't changed we pass the" ,current_fees.fee_hash)
+  current_fees = sdk_services.fetch_reverse_swap_fees(
+    breez_sdk.ReverseSwapFeesRequest(
+        send_amount_sat=None))
+  print("Total estimated fees for reverse swap:", current_fees.total_estimated_fees)
 except Exception as error:
     # Handle error
 ```
@@ -103,9 +95,8 @@ except Exception as error:
 
 ```go
 if currentFees, err := sdkServices.FetchReverseSwapFees(); err != nil {
-    log.Printf("Percentage fee for the reverse swap service: %v", currentFees.FeesPercentage)
-    log.Printf("Estimated miner fees in sats for locking up funds: %v", currentFees.FeesLockup)
-    log.Printf("Estimated miner fees in sats for claiming funds: %v", currentFees.FeesClaim)
+    log.Printf("Total estimated fees for reverse swap: %v", currentFees.TotalEstimatedFees)
+    
 }
 ```
 </section>
@@ -117,9 +108,8 @@ if currentFees, err := sdkServices.FetchReverseSwapFees(); err != nil {
 try
 {
     var currentFees = sdk.FetchReverseSwapFees();
-    Console.WriteLine($"Percentage fee for the reverse swap service: {currentFees.feesPercentage}");
-    Console.WriteLine($"Estimated miner fees in sats for locking up funds: {currentFees.feesLockup}");
-    Console.WriteLine($"Estimated miner fees in sats for claiming funds: {currentFees.feesClaim}");
+    Console.WriteLine($"Total estimated fees for reverse swap: {currentFees.totalEstimatedFees}");
+    
 }
 catch (Exception)
 {
@@ -231,7 +221,11 @@ let destinationAddress = "bc1.."
 let amountSat = currentFees.min
 let satPerVbyte = <fee rate>
 try {
-  try sdk.sendOnchain(amountSat: amountSat, onchainRecipientAddress: destinationAddress, pairHash: currentFees.feesHash, satPerVbyte: satPerVbyte)
+  try sdk.sendOnchain(
+    amountSat: amountSat,
+    onchainRecipientAddress: destinationAddress, 
+    pairHash: currentFees.feesHash,
+    satPerVbyte: satPerVbyte)
 } catch {
     // handle error
 }
@@ -295,9 +289,14 @@ try {
 destination_address = "bc1.."
 amount_sat = current_fees.min
 fee_hash = current_fees.fee_hash
+sat_per_vbyte = <fee rate>
 
 try:
-  sdk_services.send_onchain(amount_sat=amount_msats, onchain_recipient_address="...", pair_hash=fee_hash)
+  sdk_services.send_onchain(
+    amount_sat=amount_msats,
+    onchain_recipient_address="...",
+    pair_hash=current_fees.fee_hash,
+    sat_per_vbyte=sat_per_vbyte)
 except Exception as error:
   # Handle erorr
 ```

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -21,12 +21,14 @@ info!("Estimated miner fees in sats for claiming funds: {}", current_fees.fees_c
 <section>
 
 ```swift
+let sendAmountSat:UInt64 = 1_000_000
 try {
-  let currentFees = try sdk.fetchReverseSwapFees()
-
-  println("Percentage fee for the reverse swap service: \(currentFees.feesPercentage)")
-  println("Estimated miner fees in sats for locking up funds: \(currentFees.feesLockup)")
-  println("Estimated miner fees in sats for claiming funds: \(currentFees.feesClaim)")
+ let currentFees = try sdk.fetchReverseSwapFees(
+      req: ReverseSwapFeesRequest(sendAmountSat: sendAmountSat))
+  print("Percentage fee for the reverse swap service: \(currentFees.feesPercentage)")
+  print("Estimated miner fees in sats for locking up funds: \(currentFees.feesLockup)")
+  print("Estimated miner fees in sats for claiming funds: \(currentFees.feesClaim)")
+  print("In order to verify that the fetched fee hasn't changed we pass the fee hash: \(currentFees.feesHash)")
 } catch {
     // handle error
 }
@@ -84,11 +86,13 @@ try {
 <section>
 
 ```python
+send_amount_sat = 1000000
 try: 
-  current_fees = sdk_services.fetch_reverse_swap_fees()
-  print("Percentage fee for the reverse swap service: ", current_fees.fees_percentage)
-  print("Estimated miner fees in sats for locking up funds: ", current_fees.fees_lockup)
-  print("Estimated miner fees in sats for claiming funds: ", current_fees.fees_claim)
+  current_fees = sdk_services.fetch_reverse_swap_fees(breez_sdk.ReverseSwapFeesRequest(send_amount_sat=send_amount_sat))
+  print("Percentage fee for the reverse swap service:", current_fees.fees_percentage)
+  print("Estimated miner fees in sats for locking up funds:", current_fees.fees_lockup)
+  print("Estimated miner fees in sats for claiming funds:", current_fees.fees_claim)
+  print("In order to verify that the fetched fee hasn't changed we pass the" ,current_fees.fee_hash)
 except Exception as error:
     # Handle error
 ```
@@ -290,9 +294,10 @@ try {
 ```python
 destination_address = "bc1.."
 amount_sat = current_fees.min
+fee_hash = current_fees.fee_hash
 
 try:
-  sdk.send_onchain(amount_sat, destination_address, current_fees.fees_hash)
+  sdk_services.send_onchain(amount_sat=amount_msats, onchain_recipient_address="...", pair_hash=fee_hash)
 except Exception as error:
   # Handle erorr
 ```

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -66,7 +66,7 @@ try {
 try {
     ReverseSwapPairInfo currentFees = await fetchReverseSwapFees();
 
-    print(`Total estimated fees for reverse swap: ${currentFees.totalEstimatedFees}`);
+    print("Total estimated fees for reverse swap: ${currentFees.totalEstimatedFees}");
 } catch (error) {
     // handle error
 }
@@ -161,8 +161,8 @@ console.log(`Maximum amount, in sats: ${currentFees.max}`);
 <section>
 
 ```dart
-print(`Minimum amount, in sats: ${currentFees.min}`);
-print(`Maximum amount, in sats: ${currentFees.max}`);
+print("Minimum amount, in sats: ${currentFees.min}");
+print("Maximum amount, in sats: ${currentFees.max}");
 ```
 </section>
 
@@ -262,7 +262,7 @@ try {
 
 ```dart
 String destinationAddress = "bc1..";
-int amountSat = currentFees.min;
+int amountSat = <amount>;
 int satPerVbyte = <fee rate>
 try {
     ReverseSwapInfo reverseSwapInfo = await sendOnchain(


### PR DESCRIPTION
What is done

moved the connecting to LSP from page 6 to page page 4 since I believe it makes more sense as many of the examples depend on `lsp_info`params. 

Updated the examples to work with the upcoming release of the sdk.

I have not updated the examples for fee calculation, will add this later.