### PR TITLE
Add buy btc using Moonpay general instructions and an Android example

### DIFF
--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -2,6 +2,10 @@
 
 This section of the Breez SDK documentation provides an example on purchasing Bitcoin using Moonpay as the provider. The example code snippet demonstrates how to initiate a Bitcoin purchase transaction using the Breez SDK.
 
+The SDK will generate a Bitcoin address and prepare an URL using the specified provider. The user needs to open the URL and proceed with the provider flow to buy the Bitcoin.
+
+Once the acquisition is completed, the provider will transfer the Bitcoin to the generated address and Breez SDK will add the received Bitcoin to the Lightning balance.
+
 <custom-tabs category="lang">
 
 <div slot="title">Rust</div>
@@ -32,8 +36,17 @@ do {
 <div slot="title">Android</div>
 <section>
 
-```kotlin,ignore
-// TODO add docs
+```kotlin
+try {
+    // Choose your provider
+    val provider = BuyBitcoinProvider.MOONPAY
+    // request the url to proceed with the Bitcoin acquisition
+    val url = sdk.buyBitcoin(BuyBitcoinRequest(provider)).url
+    // Opens the url in the browser to buy on provider's site
+    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+} catch (e: Exception) {
+    // Handle error
+}
 ```
 </section>
 

--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -4,7 +4,7 @@ This section of the Breez SDK documentation provides an example on purchasing Bi
 
 The SDK will generate a Bitcoin address and prepare a URL using the specified provider. The user needs to open the URL and proceed with the provider flow to buy the Bitcoin.
 
-Once the acquisition is completed, the provider will transfer the Bitcoin to the generated address and Breez SDK will add the received Bitcoin to the Lightning balance.
+Once the buy is completed, the provider will transfer the Bitcoin to the generated address and Breez SDK will add the received Bitcoin to the Lightning balance.
 
 <custom-tabs category="lang">
 

--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -2,7 +2,7 @@
 
 This section of the Breez SDK documentation provides an example on purchasing Bitcoin using Moonpay as the provider. The example code snippet demonstrates how to initiate a Bitcoin purchase transaction using the Breez SDK.
 
-The SDK will generate a Bitcoin address and prepare an URL using the specified provider. The user needs to open the URL and proceed with the provider flow to buy the Bitcoin.
+The SDK will generate a Bitcoin address and prepare a URL using the specified provider. The user needs to open the URL and proceed with the provider flow to buy the Bitcoin.
 
 Once the acquisition is completed, the provider will transfer the Bitcoin to the generated address and Breez SDK will add the received Bitcoin to the Lightning balance.
 

--- a/src/guide/install.md
+++ b/src/guide/install.md
@@ -56,7 +56,7 @@ dependencies {
 }
 ```
 
-See [the example](https://github.com/breez/breez-sdk/tree/main/libs/sdk-bindings/bindings-android/example) for more details
+See [the example](https://github.com/breez/breez-sdk-examples/tree/main/Android) for more details
 
 ## React Native
 

--- a/src/guide/payments.md
+++ b/src/guide/payments.md
@@ -44,7 +44,10 @@ do {
 
 ```kotlin,ignore
 try {
-    val invoice = sdk.receivePayment(3000L.toULong(), "Invoice for 3000 sats")
+    val invoice = sdk.receivePayment(ReceivePaymentRequest(
+        3000L.toULong(),
+        "Invoice for 3000 sats",
+    ))
 } catch (e: Exception) {
     // handle error
 }

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -39,7 +39,7 @@ do {
 
 ```kotlin,ignore
 try {
-    val swapInfo = sdk.receiveOnchain()
+    val swapInfo = sdk.receiveOnchain(ReceiveOnchainRequest())
     // Send your funds to the bellow bitcoin address
     val address = swapInfo.bitcoinAddress
 } catch (e: Exception) {


### PR DESCRIPTION
Also updating the android examples with the most recent SDK changes.

![buy btc doc](https://github.com/breez/breez-sdk-docs/assets/1225438/3fdc91c5-943c-4aed-8506-2e46a84e0adf)
