### PR TITLE
Extract code snippets and reference them from doc files (Part 2 of 2)

### DIFF
--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -19,7 +19,7 @@ Once the buy is completed, the provider will transfer the Bitcoin to the generat
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
   let buyBitcoinResponse = try sdk.buyBitcoin(
     req: BuyBitcoinRequest(provider: .moonpay))
@@ -32,7 +32,7 @@ do {
 <div slot="title">Kotlin</div>
 <section>
 
-```kotlin
+```kotlin,ignore
 try {
     // Choose your provider
     val provider = BuyBitcoinProvider.MOONPAY
@@ -57,7 +57,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/buy_btc.dart:buy-btc}}
 ```
 </section>
@@ -65,7 +65,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
     buy_bitcoin_resp = sdk_services.buy_bitcoin(
         breez_sdk.BuyBitcoinRequest(
@@ -78,7 +78,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/buy_btc.go:buy-btc}}
 ```
 </section>
@@ -87,7 +87,7 @@ except Exception as error:
 
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/BuyBtc.cs:buy-btc}}
 ```
 </section>

--- a/src/guide/connecting_lsp.md
+++ b/src/guide/connecting_lsp.md
@@ -14,7 +14,7 @@ Based on the API key provided to the Breez SDK, a default LSP is selected for yo
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
     let lspId = try sdk.lspId() 
     let lspInfo = try sdk.lspInfo()
@@ -52,7 +52,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/connecting_lsp.dart:get-lsp-info}}
 ```
 </section>
@@ -60,7 +60,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python 
+```python,ignore 
 try: 
     lsp_id = sdk_services.lsp_id()
     lsp_info = sdk_services.lsp_info()
@@ -73,7 +73,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/connecting_lsp.go:get-lsp-info}}
 ```
 </section>
@@ -81,7 +81,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ConnectingLsp.cs:get-lsp-info}}
 ```
 </section>
@@ -101,7 +101,7 @@ When you have selected an LSP you may then connect to it.
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
     try sdk.connectLsp(lspId: lspId!)
 } catch {
@@ -133,7 +133,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/connecting_lsp.dart:connect-lsp}}
 ```
 </section>
@@ -141,7 +141,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try: 
     sdk_services.connect_lsp(lsp_id)
 except Exception as error:
@@ -152,7 +152,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/connecting_lsp.go:connect-lsp}}
 ```
 </section>
@@ -160,7 +160,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ConnectingLsp.cs:connect-lsp}}
 ```
 </section>

--- a/src/guide/fiat_currencies.md
+++ b/src/guide/fiat_currencies.md
@@ -34,7 +34,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/fiat_currencies.dart:list-fiat-currencies}}
 ```
 </section>
@@ -42,7 +42,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try: 
     fiat_currencies = sdk_services.list_fiat_currencies()
 
@@ -54,7 +54,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/fiat_currencies.go:list-fiat-currencies}}
 ```
 </section>
@@ -62,7 +62,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/FiatCurrencies.cs:list-fiat-currencies}}
 ```
 </section>
@@ -102,7 +102,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/fiat_currencies.dart:fetch-fiat-rates}}
 ```
 </section>
@@ -110,7 +110,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
     fiat_rates = sdk_services.fetch_fiat_rates()
     # print your desired rate 
@@ -122,7 +122,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/fiat_currencies.go:fetch-fiat-rates}}
 ```
 </section>
@@ -130,7 +130,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/FiatCurrencies.cs:fetch-fiat-rates}}
 ```
 </section>
@@ -188,7 +188,7 @@ fun fiatCurrenciesAndRate(): Map<FiatCurrency, Rate> = try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/fiat_currencies.dart:get-fiat-currencies-and-rates}}
 ```
 </section>
@@ -196,7 +196,7 @@ fun fiatCurrenciesAndRate(): Map<FiatCurrency, Rate> = try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 # TODO
 ```
 </section>
@@ -204,7 +204,7 @@ fun fiatCurrenciesAndRate(): Map<FiatCurrency, Rate> = try {
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/fiat_currencies.go:get-fiat-currencies-and-rates}}
 ```
 </section>
@@ -212,7 +212,7 @@ fun fiatCurrenciesAndRate(): Map<FiatCurrency, Rate> = try {
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/FiatCurrencies.cs:get-fiat-currencies-and-rates}}
 ```
 </section>

--- a/src/guide/getting_started.md
+++ b/src/guide/getting_started.md
@@ -50,7 +50,7 @@ Now your SDK is ready to be used.
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 // SDK events listener
 class SDKListener: EventListener {
   func onEvent(e: BreezEvent) {
@@ -125,7 +125,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/getting_started.dart:init-sdk}}
 ```
 </section>
@@ -133,7 +133,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 # SDK events listener
 class SDKListener(breez_sdk.EventListener):
    def on_event(self, event):
@@ -160,7 +160,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/getting_started.go:init-sdk}}
 ```
 </section>
@@ -168,7 +168,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/GettingStarted.cs:init-sdk}}
 ```
 </section>
@@ -188,7 +188,7 @@ At any point we can fetch our balance from the Greenlight node:
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
   let nodeInfo = try sdk.nodeInfo()
   let lnBalance = nodeInfo?.channelsBalanceMsat
@@ -224,7 +224,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/getting_started.dart:fetch-balance}}
 ```
 </section>
@@ -232,7 +232,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try: 
     node_info = node_info()
     ln_balance = node_info.channels_balance_msat
@@ -245,7 +245,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/getting_started.go:fetch-balance}}
 ```
 </section>
@@ -253,7 +253,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/GettingStarted.cs:fetch-balance}}
 ```
 </section>

--- a/src/guide/list_payments.md
+++ b/src/guide/list_payments.md
@@ -14,7 +14,7 @@ To view your payment history you can list and filter all the sent and received p
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
     let payments = try sdk.listPayments(req: ListPaymentsRequest(filter: PaymentTypeFilter.all))
 } catch {
@@ -46,7 +46,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/list_payments.dart:list-payments}}
 ```
 </section>
@@ -54,7 +54,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
   sdk_services.list_payments(breez_sdk.ListPaymentsRequest(breez_sdk.PaymentTypeFilter.All))
 except Exception as error:
@@ -65,7 +65,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/list_payments.go:list-payments}}
 ```
 </section>
@@ -73,7 +73,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ListPayments.cs:list-payments}}
 ```
 </section>
@@ -93,7 +93,7 @@ You can optionally filter payments by timestamp and include failed payments.
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
     let payments = try sdk.listPayments(
         req: ListPaymentsRequest(
@@ -131,7 +131,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/list_payments.dart:list-payments-filtered}}
 ```
 </section>
@@ -139,7 +139,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
   sdk_services.list_payments(
     breez_sdk.ListPaymentsRequest(
@@ -154,7 +154,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/list_payments.go:list-payments-filtered}}
 ```
 </section>
@@ -162,7 +162,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ListPayments.cs:list-payments-filtered}}
 ```
 </section>

--- a/src/guide/lnurl_auth.md
+++ b/src/guide/lnurl_auth.md
@@ -13,7 +13,7 @@
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 // Endpoint can also be of the form:
 // keyauth://domain.com/auth?key=val
 let lnurlAuthUrl = "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4excttvdankjm3lw3skw0tvdankjm3xdvcn6vtp8q6n2dfsx5mrjwtrxdjnqvtzv56rzcnyv3jrxv3sxqmkyenrvv6kve3exv6nqdtyv43nqcmzvdsnvdrzx33rsenxx5unqc3cxgeqgntfgu"
@@ -68,7 +68,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/lnurl_auth.dart:lnurl-auth}}
 ```
 </section>
@@ -76,7 +76,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 # Endpoint can also be of the form:
 # keyauth://domain.com/auth?key=val
 lnurl_auth_url = "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4excttvdankjm3lw3skw0tvdankjm3xdvcn6vtp8q6n2dfsx5mrjwtrxdjnqvtzv56rzcnyv3jrxv3sxqmkyenrvv6kve3exv6nqdtyv43nqcmzvdsnvdrzx33rsenxx5unqc3cxgeqgntfgu"
@@ -97,7 +97,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/lnurl_auth.go:lnurl-auth}}
 ```
 </section>
@@ -105,7 +105,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/LnurlAuth.cs:lnurl-auth}}
 ```
 </section>

--- a/src/guide/lnurl_pay.md
+++ b/src/guide/lnurl_pay.md
@@ -14,7 +14,7 @@
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 // Endpoint can also be of the form:
 // lnurlp://domain.com/lnurl-pay?key=val
 // lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4excttsv9un7um9wdekjmmw84jxywf5x43rvv35xgmr2enrxanr2cfcvsmnwe3jxcukvde48qukgdec89snwde3vfjxvepjxpjnjvtpxd3kvdnxx5crxwpjvyunsephsz36jf
@@ -66,7 +66,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/lnurl_pay.dart:lnurl-pay}}
 ```
 </section>
@@ -74,7 +74,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 # Endpoint can also be of the form:
 # lnurlp://domain.com/lnurl-pay?key=val
 # lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4excttsv9un7um9wdekjmmw84jxywf5x43rvv35xgmr2enrxanr2cfcvsmnwe3jxcukvde48qukgdec89snwde3vfjxvepjxpjnjvtpxd3kvdnxx5crxwpjvyunsephsz36jf
@@ -97,7 +97,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/lnurl_pay.go:lnurl-pay}}
 ```
 </section>
@@ -105,7 +105,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/LnurlPay.cs:lnurl-pay}}
 ```
 </section>

--- a/src/guide/lnurl_withdraw.md
+++ b/src/guide/lnurl_withdraw.md
@@ -15,7 +15,7 @@
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 // Endpoint can also be of the form:
 // lnurlw://domain.com/lnurl-withdraw?key=val
 let lnurlWithdrawUrl = "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4exctthd96xserjv9mn7um9wdekjmmw843xxwpexdnxzen9vgunsvfexq6rvdecx93rgdmyxcuxverrvcursenpxvukzv3c8qunsdecx33nzwpnvg6ryc3hv93nzvecxgcxgwp3h33lxk"
@@ -70,7 +70,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/lnurl_withdraw.dart:lnurl-withdraw}}
 ```
 </section>
@@ -78,7 +78,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 # Endpoint can also be of the form:
 # lnurlw://domain.com/lnurl-withdraw?key=val
 lnurl_withdraw_url = "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4exctthd96xserjv9mn7um9wdekjmmw843xxwpexdnxzen9vgunsvfexq6rvdecx93rgdmyxcuxverrvcursenpxvukzv3c8qunsdecx33nzwpnvg6ryc3hv93nzvecxgcxgwp3h33lxk"
@@ -96,7 +96,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/lnurl_withdraw.go:lnurl-withdraw}}
 ```
 </section>
@@ -104,7 +104,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/LnurlWithdraw.cs:lnurl-withdraw}}
 ```
 </section>

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -17,7 +17,7 @@ In order to receive funds you first have to be connected to an [LSP](connecting_
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
   let swapInfo = try sdk.receiveOnchain(req: ReceiveOnchainRequest())
 
@@ -54,7 +54,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/receive_onchain.dart:generate-receive-onchain-address}}
 ```
 </section>
@@ -62,7 +62,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try: 
     swap_info = sdk_services.receive_onchain(breez_sdk.ReceiveOnchainRequest())
 
@@ -76,7 +76,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/receive_onchain.go:generate-receive-onchain-address}}
 ```
 </section>
@@ -84,7 +84,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ReceiveOnchain.cs:generate-receive-onchain-address}}
 ```
 </section>
@@ -104,7 +104,7 @@ Once you've sent the funds to the above address, the SDK will monitor this addre
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
   let swapInfo = try sdk.inProgressSwap()
 } catch {
@@ -136,7 +136,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/receive_onchain.dart:in-progress-swap}}
 ```
 </section>
@@ -144,7 +144,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
     swap_info = sdk_services.in_progress_swap()
 except Exception as error:
@@ -155,7 +155,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 
 {{#include ../../snippets/go/receive_onchain.go:in-progress-swap}}
 ```
@@ -164,7 +164,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ReceiveOnchain.cs:in-progress-swap}}
 ```
 </section>
@@ -189,7 +189,7 @@ In order to execute a refund, you need to supply an on-chain address to where th
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
   let refundables = try sdk.listRefundables()
 } catch {
@@ -221,7 +221,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/receive_onchain.dart:list-refundables}}
 ```
 </section>
@@ -229,7 +229,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
     refundables = sdk_services.list_refundables()
 except Exception as error:
@@ -240,7 +240,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/receive_onchain.go:list-refundables}}
 ```
 </section>
@@ -248,7 +248,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ReceiveOnchain.cs:list-refundables}}
 ```
 </section>
@@ -268,7 +268,7 @@ Once you have a refundable swap in hand, use the following code to execute a ref
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 let destinationAddress = "..."
 let satPerVbyte = <refund tx fee rate>
 
@@ -309,7 +309,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/receive_onchain.dart:execute-refund}}
 ```
 </section>
@@ -317,7 +317,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 destination_address = "..."
 sat_per_vbyte = 5
 
@@ -333,7 +333,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/receive_onchain.go:execute-refund}}
 ```
 </section>
@@ -341,7 +341,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ReceiveOnchain.cs:execute-refund}}
 ```
 </section>
@@ -365,7 +365,7 @@ To calculate the fees for a channel being opened by the LSP:
 <div slot="title">Swift</div>
 <section>
 
-```swift 
+```swift,ignore 
 let amountMsat = <amount msat>
 do {
     let channelFees = try sdk.openChannelFee(
@@ -395,7 +395,7 @@ do {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/receive_onchain.dart:get-channel-opening-fees}}
 ```
 </section>
@@ -403,7 +403,7 @@ do {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 amount_msat = <amount msats>
 try:
     channel_fees = sdk_services.open_channel_fee(
@@ -417,7 +417,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/receive_onchain.go:get-channel-opening-fees}}
 ```
 </section>
@@ -425,13 +425,10 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs 
+```cs,ignore 
 {{#include ../../snippets/csharp/ReceiveOnchain.cs:get-channel-opening-fees}}
 ```
 </section>
-</custom-tabs>
-
-
 </custom-tabs>
 
 

--- a/src/guide/receive_payment.md
+++ b/src/guide/receive_payment.md
@@ -15,7 +15,7 @@ The Breez SDK automatically connects your node to the LSP peer and you can now r
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
   let invoice = try sdk.receivePayment(
     req: ReceivePaymentRequest(
@@ -53,7 +53,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/receive_payment.dart:receive-payment}}
 ```
 </section>
@@ -61,7 +61,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
   receive_payment_response = sdk_services.receive_payment(
     breez_sdk.ReceivePaymentRequest(
@@ -75,7 +75,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/receive_payment.go:receive-payment}}
 ```
 </section>
@@ -83,7 +83,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/ReceivePayment.cs:receive-payment}}
 ```
 </section>

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -16,7 +16,7 @@ First, fetch the current reverse swap fees:
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 let sendAmountSat:UInt64? = 50000
 try {
   let currentFees = try sdk.fetchReverseSwapFees(
@@ -52,7 +52,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/send_onchain.dart:estimate-current-reverse-swap-total-fees}}
 ```
 </section>
@@ -60,7 +60,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try: 
     current_fees = sdk_services.fetch_reverse_swap_fees(
         breez_sdk.ReverseSwapFeesRequest(send_amount_sat=50000))
@@ -73,7 +73,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/send_onchain.go:estimate-current-reverse-swap-total-fees}}
 ```
 </section>
@@ -81,7 +81,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/SendOnchain.cs:estimate-current-reverse-swap-total-fees}}
 ```
 </section>
@@ -105,7 +105,7 @@ Fetching the fees also tells you what is the range of amounts you can send:
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 println("Minimum amount, in sats: \(current_fees.min)")
 println("Maximum amount, in sats: \(current_fees.max)")
 ```
@@ -131,7 +131,7 @@ Log.v("Breez", "Maximum amount, in sats: ${fees.max}")
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/send_onchain.dart:get-current-reverse-swap-min-max}}
 ```
 </section>
@@ -139,7 +139,7 @@ Log.v("Breez", "Maximum amount, in sats: ${fees.max}")
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 print("Minimum amount, in sats: ", current_fees.min)
 print("Maximum amount, in sats: ", current_fees.max)
 ```
@@ -148,7 +148,7 @@ print("Maximum amount, in sats: ", current_fees.max)
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/send_onchain.go:get-current-reverse-swap-min-max}}
 ```
 </section>
@@ -156,7 +156,7 @@ print("Maximum amount, in sats: ", current_fees.max)
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/SendOnchain.cs:get-current-reverse-swap-min-max}}
 ```
 </section>
@@ -176,7 +176,7 @@ Once you checked the fees are acceptable, you can start the reverse swap:
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 let destinationAddress = "bc1.."
 let amountSat = currentFees.min
 let satPerVbyte = <fee rate>
@@ -218,7 +218,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/send_onchain.dart:start-reverse-swap}}
 ```
 </section>
@@ -226,7 +226,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 destination_address = "bc1.."
 amount_sat = 50000
 sat_per_vbyte = 5
@@ -243,7 +243,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/send_onchain.go:start-reverse-swap}}
 ```
 </section>
@@ -251,7 +251,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/SendOnchain.cs:start-reverse-swap}}
 ```
 </section>
@@ -275,7 +275,7 @@ You can check its status with:
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 for rs in sdk.inProgressReverseSwaps() {
   println("Reverse swap \(rs.id) in progress, status is \(rs.status)")
 }
@@ -303,7 +303,7 @@ for (rs in sdk.inProgressReverseSwaps()) {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/send_onchain.dart:check-reverse-swaps-status}}
 ```
 </section>
@@ -311,7 +311,7 @@ for (rs in sdk.inProgressReverseSwaps()) {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try: 
   reverse_swaps = sdk_services.in_progress_reverse_swaps()
   for rs in reverse_swaps:
@@ -324,7 +324,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/send_onchain.go:check-reverse-swaps-status}}
 ```
 </section>
@@ -332,7 +332,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/SendOnchain.cs:check-reverse-swaps-status}}
 ```
 </section>

--- a/src/guide/send_payment.md
+++ b/src/guide/send_payment.md
@@ -14,7 +14,7 @@ Once you have outbound liquidity you can start sending payments too.
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
   // The `amountMsat` param is optional and should only passed if the bolt11 doesn't specify an amount.
   // The amountMsat is required in case an amount is not specified in the bolt11 invoice'.
@@ -54,7 +54,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/send_payment.dart:send-payment}}
 ```
 </section>
@@ -62,7 +62,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 bolt11 = "..."
 try:
   # The `amount_msat` param is optional and should only passed if the bolt11 doesn't specify an amount.
@@ -77,7 +77,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/send_payment.go:send-payment}}
 ```
 </section>
@@ -85,7 +85,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/SendPayment.cs:send-payment}}
 ```
 </section>

--- a/src/guide/send_spontaneous_payment.md
+++ b/src/guide/send_spontaneous_payment.md
@@ -14,7 +14,7 @@ They can even be spontaneous payments to a node without a bolt11 invoice.
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 let nodeId = "...";
 do {
     let response = try sdk.sendSpontaneousPayment(
@@ -53,7 +53,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/send_spontaneous_payment.dart:send-spontaneous-payment}}
 ```
 </section>
@@ -61,7 +61,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
     sdk_services.send_spontaneous_payment(
         breez_sdk.SendSpontaneousPaymentRequest(
@@ -75,7 +75,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/send_spontaneous_payment.go:send-spontaneous-payment}}
 ```
 </section>
@@ -83,7 +83,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/SendSpontaneousPayment.cs:send-spontaneous-payment}}
 ```
 </section>

--- a/src/guide/static_channel_backup.md
+++ b/src/guide/static_channel_backup.md
@@ -20,7 +20,7 @@ In order to use the recoverchannel method, the user needs to provide the static 
 <div slot="title">Swift</div>
 <section>
 
-```swift
+```swift,ignore
 do {
     let backupData = breez_sdk.staticBackup(request: StaticBackupRequest(workingDir: "<working directory>"));
 } catch{
@@ -55,7 +55,7 @@ try {
 <div slot="title">Dart</div>
 <section>
 
-```dart
+```dart,ignore
 {{#include ../../snippets/dart_snippets/lib/static_channel_backup.dart:static-channel-backup}}
 ```
 </section>
@@ -63,7 +63,7 @@ try {
 <div slot="title">Python</div>
 <section>
 
-```python
+```python,ignore
 try:
     backup_data = breez_sdk.static_backup(breez_sdk.StaticBackupRequest(working_dir="<working directory>"))
 except Exception as error:
@@ -74,7 +74,7 @@ except Exception as error:
 <div slot="title">Go</div>
 <section>
 
-```go
+```go,ignore
 {{#include ../../snippets/go/static_channel_backup.go:static-channel-backup}}
 ```
 </section>
@@ -82,7 +82,7 @@ except Exception as error:
 <div slot="title">C#</div>
 <section>
 
-```cs
+```cs,ignore
 {{#include ../../snippets/csharp/StaticChannelBackup.cs:static-channel-backup}}
 ```
 </section>


### PR DESCRIPTION
This PR adds the missing languages and CI steps that were not yet ready for Part 1 (https://github.com/breez/breez-sdk-docs/pull/72).


---

Snippet extracted to sub-project:

* [x] Rust
* [ ] Swift
* [ ] Kotlin
* [x] React Native
* [x] Dart
* [ ] Python
* [x] Go
* [x] C#

CI checks compilation on `main` and new PRs:

* [x] Rust
* [ ] Swift
* [ ] Kotlin
* [ ] React Native
* [x] Dart
* [ ] Python
* [ ] Go
* [x] C#