### PR TITLE
only publish on pushes to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
     with:
       repository: breez/breez-sdk
       ref: ${{ needs.setup.outputs.sdk-ref }}
-      csharp-package-version: ${{ needs.setup.outputs.package-version }}
-      flutter-package-version: ${{ needs.setup.outputs.package-version }}
+      package-version: ${{ needs.setup.outputs.package-version }}
+      packages-to-publish: '["csharp", "flutter"]'
       use-dummy-binaries: true
 
   check-rust:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,7 @@ jobs:
           path: book
 
       - name: Push book to main-generated branch
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} 
         run: |
           git config --global user.name "Generator"
           git config --global user.email "no-reply@breez.technology"


### PR DESCRIPTION
The `main` branch doesn't exist in pull request CI. I hope maybe if the publish step is only run on pushes to main, the main branch actually exists.