### PR TITLE
Add production Greenlight credentials example

### DIFF
--- a/snippets/csharp/Production.cs
+++ b/snippets/csharp/Production.cs
@@ -1,0 +1,18 @@
+using Breez.Sdk;
+
+public class ProductionSnippets
+{
+    public NodeConfig ProductionNodeConfig() {
+        // ANCHOR: moving-to-production
+        // Read your Greenlight credentials from secure storage
+        var deviceKey = new List<byte>();
+        var deviceCert = new List<byte>();
+        var greenlightCredentials = new GreenlightCredentials(deviceKey, deviceCert);
+        
+        var nodeConfig = new NodeConfig.Greenlight(
+            new GreenlightNodeConfig(greenlightCredentials, null)
+        );
+        // ANCHOR_END: moving-to-production
+        return nodeConfig;
+    }
+}

--- a/snippets/dart_snippets/lib/production.dart
+++ b/snippets/dart_snippets/lib/production.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 NodeConfig productionNodeConfig() {
@@ -8,7 +7,10 @@ NodeConfig productionNodeConfig() {
   // Read your Greenlight credentials from secure storage
   Uint8List deviceKey = Uint8List(0);
   Uint8List deviceCert = Uint8List(0);
-  GreenlightCredentials greenlightCredentials = GreenlightCredentials(deviceKey, deviceCert);
+  GreenlightCredentials greenlightCredentials = GreenlightCredentials(
+    deviceKey: deviceKey, 
+    deviceCert: deviceCert,
+  );
 
   NodeConfig nodeConfig = NodeConfig.greenlight(
     config: GreenlightNodeConfig(

--- a/snippets/dart_snippets/lib/production.dart
+++ b/snippets/dart_snippets/lib/production.dart
@@ -6,8 +6,8 @@ import 'package:breez_sdk/bridge_generated.dart';
 NodeConfig productionNodeConfig() {
   // ANCHOR: moving-to-production
   // Read your Greenlight credentials from secure storage
-  Uint8List deviceKey = Uint8List();
-  Uint8List deviceCert = Uint8List();
+  Uint8List deviceKey = Uint8List(0);
+  Uint8List deviceCert = Uint8List(0);
   GreenlightCredentials greenlightCredentials = GreenlightCredentials(deviceKey, deviceCert);
 
   NodeConfig nodeConfig = NodeConfig.greenlight(
@@ -17,5 +17,5 @@ NodeConfig productionNodeConfig() {
     ),
   );
   // ANCHOR_END: moving-to-production
-  return nodeConfig
+  return nodeConfig;
 }

--- a/snippets/dart_snippets/lib/production.dart
+++ b/snippets/dart_snippets/lib/production.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+
+import 'package:breez_sdk/breez_sdk.dart';
+import 'package:breez_sdk/bridge_generated.dart';
+
+NodeConfig productionNodeConfig() {
+  // ANCHOR: moving-to-production
+  // Read your Greenlight credentials from secure storage
+  Uint8List deviceKey = Uint8List();
+  Uint8List deviceCert = Uint8List();
+  GreenlightCredentials greenlightCredentials = GreenlightCredentials(deviceKey, deviceCert);
+
+  NodeConfig nodeConfig = NodeConfig.greenlight(
+    config: GreenlightNodeConfig(
+      partnerCredentials: greenlightCredentials,
+      inviteCode: null,
+    ),
+  );
+  // ANCHOR_END: moving-to-production
+  return nodeConfig
+}

--- a/snippets/go/production.go
+++ b/snippets/go/production.go
@@ -12,7 +12,7 @@ func ProductionNodeConfig() breez_sdk.NodeConfig {
 	greenlightCredentials := breez_sdk.GreenlightCredentials{
 		DeviceKey:  deviceKey,
 		DeviceCert: deviceCert,
-	};
+	}
 
 	nodeConfig := breez_sdk.NodeConfigGreenlight{
 		Config: breez_sdk.GreenlightNodeConfig{

--- a/snippets/go/production.go
+++ b/snippets/go/production.go
@@ -1,0 +1,25 @@
+package example
+
+import (
+	"github.com/breez/breez-sdk-go/breez_sdk"
+)
+
+func ProductionNodeConfig() breez_sdk.NodeConfig {
+	// ANCHOR: moving-to-production
+	// Read your Greenlight credentials from secure storage
+	deviceKey := []uint8{}
+	deviceCert := []uint8{}
+	greenlightCredentials := breez_sdk.GreenlightCredentials{
+		DeviceKey:  deviceKey,
+		DeviceCert: deviceCert,
+	};
+
+	nodeConfig := breez_sdk.NodeConfigGreenlight{
+		Config: breez_sdk.GreenlightNodeConfig{
+			PartnerCredentials: &greenlightCredentials,
+			InviteCode:         nil,
+		},
+	}
+	// ANCHOR_END: moving-to-production
+	return nodeConfig
+}

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Production.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Production.kt
@@ -1,0 +1,16 @@
+package com.example.kotlinmpplib
+
+import breez_sdk.*
+class Production {
+    fun productionNodeConfig(): NodeConfig {
+        // ANCHOR: moving-to-production
+        // Read your Greenlight credentials from secure storage
+        val deviceKey = emptyList<UByte>()
+        val deviceCert = emptyList<UByte>()
+        val greenlightCredentials = GreenlightCredentials(deviceKey, deviceCert)
+
+        val nodeConfig = NodeConfig.Greenlight(GreenlightNodeConfig(greenlightCredentials, null))
+        // ANCHOR_END: moving-to-production
+        return nodeConfig
+    }
+}

--- a/snippets/python/main.py
+++ b/snippets/python/main.py
@@ -14,6 +14,8 @@ from src.fiat_currencies import list_supported_fiat_currencies, get_current_rate
 from src.lnurl_auth import auth
 from src.lnurl_pay import pay
 from src.lnurl_withdraw import withdraw
+from src.production import production_node_config
+from src.service_status import health_check_status, report_payment_failure
 import tempfile
 import os
 
@@ -80,7 +82,12 @@ def main():
    # lnurl withdraw 
    withdraw(sdk_services)
 
+   # moving to production
+   production_node_config()
 
+   # service status
+   health_check_status(sdk_services)
+   report_payment_failure(sdk_services)
 
    # use temp_dir, and remove when done:
    temp_dir.cleanup()

--- a/snippets/python/src/production.py
+++ b/snippets/python/src/production.py
@@ -1,0 +1,13 @@
+import breez_sdk
+
+def production_node_config():
+    # ANCHOR: moving-to-production
+    # Read your Greenlight credentials from secure storage
+    deviceKey = []
+    deviceCert = []
+    greenlightCredentials = breez_sdk.GreenlightCredentials(deviceKey, deviceCert)
+
+    node_config = breez_sdk.NodeConfig.GREENLIGHT(
+        breez_sdk.GreenlightNodeConfig(greenlightCredentials, None))
+    # ANCHOR_END: moving-to-production
+    return node_config

--- a/snippets/react-native/production.ts
+++ b/snippets/react-native/production.ts
@@ -1,0 +1,25 @@
+import {
+  type GreenlightCredentials,
+  type NodeConfig,
+  NodeConfigVariant
+} from '@breeztech/react-native-breez-sdk'
+
+const productionNodeConfig = (): NodeConfig => {
+  // ANCHOR: moving-to-production
+  // Read your Greenlight credentials from secure storage
+  const deviceKey: number[] = []
+  const deviceCert: number[] = []
+  const greenlightCredentials: GreenlightCredentials = {
+    deviceKey,
+    deviceCert
+  }
+
+  const nodeConfig: NodeConfig = {
+    type: NodeConfigVariant.GREENLIGHT,
+    config: {
+      partnerCredentials: greenlightCredentials
+    }
+  }
+  // ANCHOR_END: moving-to-production
+  return nodeConfig
+}

--- a/snippets/rust/src/main.rs
+++ b/snippets/rust/src/main.rs
@@ -6,6 +6,7 @@ mod list_payments;
 mod lnurl_auth;
 mod lnurl_pay;
 mod lnurl_withdraw;
+mod production;
 mod receive_onchain;
 mod receive_payment;
 mod send_onchain;

--- a/snippets/rust/src/production.rs
+++ b/snippets/rust/src/production.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use breez_sdk_core::*;
+
+
+fn production_node_config() -> Result<NodeConfig> {
+    // ANCHOR: moving-to-production
+    // Read your Greenlight credentials from secure storage
+    let device_key: Vec<u8> = vec![];
+    let device_cert: Vec<u8> = vec![];
+    let greenlight_credentials = GreenlightCredentials {
+        device_key, 
+        device_cert,
+    };
+
+    let node_config = NodeConfig::Greenlight {
+        config: GreenlightNodeConfig {
+            partner_credentials: Some(greenlight_credentials),
+            invite_code: None,
+        },
+    };
+    // ANCHOR_END: moving-to-production
+    Ok(node_config)
+}

--- a/snippets/swift/BreezSDKExamples/Sources/Production.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/Production.swift
@@ -1,0 +1,21 @@
+//
+//  Production.swift
+//  
+//
+//  Created by dangeross on 29/11/2023.
+//
+
+import BreezSDK
+
+func productionNodeConfig() -> NodeConfig {
+    // ANCHOR: moving-to-production
+    // Read your Greenlight credentials from secure storage
+    let deviceKey = [UInt8]()
+    let deviceCert = [UInt8]()
+    let greenlightCredentials = GreenlightCredentials(deviceKey: deviceKey, deviceCert: deviceCert)
+
+    let nodeConfig = NodeConfig.greenlight(
+            config: GreenlightNodeConfig(partnerCredentials: greenlightCredentials, inviteCode: nil))
+    // ANCHOR_END: moving-to-production
+    return nodeConfig
+}

--- a/src/guide/production.md
+++ b/src/guide/production.md
@@ -1,5 +1,71 @@
 # Moving to Production 
 
-To move your project to production, you will have to replace the evaluation invite code to a partner certificate issued by Greenlight.
+To move your project to production, you will have to replace the evaluation invite code with a partner certificate issued by Greenlight.
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/production.rs:moving-to-production}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSDKExamples/Sources/Production.swift:moving-to-production}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Production.kt:moving-to-production}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/production.ts:moving-to-production}}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/dart_snippets/lib/production.dart:moving-to-production}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore
+{{#include ../../snippets/python/src/production.py:moving-to-production}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/production.go:moving-to-production}}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+```cs,ignore
+{{#include ../../snippets/csharp/Production.cs:moving-to-production}}
+```
+</section>
+</custom-tabs>
 
 To obtain a certificate for a production environment, please contact Breez via email at contact@breez.technology.


### PR DESCRIPTION
Adds an example in each language to create a Node Config using the Greenlight partner certificate and key.

Closes #44 