### PR TITLE
Add refund section for swap-in

### DIFF
--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -72,7 +72,12 @@ In order to receive funds you first have to be connected to an [LSP](connecting_
 </section>
 </custom-tabs>
 
-It's important to be aware that the swap information provided includes maximum and minimum limits. Users must be informed of these limits because if the amount transferred to the swap address falls outside this valid range, the funds will not be successfully received via lightning. In such cases, a refund will be necessary.
+<div class="warning">
+<h4>Developer note</h4>
+
+The `swap_info` above includes maximum and minimum limits. Your application's users must be informed of these limits because if the amount transferred to the swap address falls outside this valid range, the funds will not be successfully received via lightning. In such cases, a refund will be necessary.
+
+</div>
 
 ## Get the in-progress Swap
 

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -297,7 +297,7 @@ Once you have a refundable swap in hand, use the following code to execute a ref
 <div class="warning">
 <h4>Developer note</h4>
 
-A refund can be issued several times. A common scenario where this is useful is if the initial refund transaction takes too long to mine, your application's users can be offered the ability to re-trigger the refund with a higher feerate.
+A refund can be attempted several times. A common scenario where this is useful is if the initial refund transaction takes too long to mine, your application's users can be offered the ability to re-trigger the refund with a higher feerate.
 
 </div>
 

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -156,7 +156,7 @@ The process of receiving funds via an on-chain address is trustless and uses a s
 1. Either by a preimage that is exposed when the Lightning payment is completed - this is the positive case where the swap was successful.
 2. Or by your node when the swap didn't complete within a certain timeout (216 blocks) - this is the negative case where your node will execute a refund (funds become refundable after 288 blocks). Refund will also be available in case the amount sent wasn't within the limits.
 
-## List refundable Swaps
+## Refund a Swap
 
 In order to execute a refund, you need to supply an on-chain address to where the refunded amount will be sent. The following code will retrieve the refundable swaps:
 
@@ -225,8 +225,6 @@ In order to execute a refund, you need to supply an on-chain address to where th
 ```
 </section>
 </custom-tabs>
-
-## Refund a Swap
 
 Once you have a refundable swap in hand, use the following code to execute a refund:
 

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -79,6 +79,7 @@ The `swap_info` above includes maximum and minimum limits. Your application's us
 
 </div>
 
+
 ## Get the in-progress Swap
 
 Once you've sent the funds to the above address, the SDK will monitor this address for unspent confirmed outputs and use a trustless submarine swap to receive these into your Lightning node. You can always monitor the status of the current in-progress swap using the following code:
@@ -294,6 +295,13 @@ Once you have a refundable swap in hand, use the following code to execute a ref
 ```
 </section>
 </custom-tabs>
+
+<div class="warning">
+<h4>Developer note</h4>
+
+A refund can be issued several times. A common scenario where this is useful is if the initial refund transaction takes too long to mine, your application's users can be offered the ability to re-trigger the refund with a higher feerate.
+
+</div>
 
 # Calculating fees
 

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -71,9 +71,14 @@ First, fetch the current reverse swap fees:
 </section>
 </custom-tabs>
 
+<div class="warning">
+<h4>Developer note</h4>
+
 The reverse swap will involve two on-chain transactions, for which the mining fees can only be estimated. They will happen
 automatically once the process is started, but the last two values above are these estimates to help you get a picture
 of the total costs.
+
+</div>
 
 Fetching the fees also tells you what is the range of amounts the service allows:
 


### PR DESCRIPTION
This PR does three things:

- Wraps especially important paragraphs in an [mdbook "warning" div](https://rust-lang.github.io/mdBook/format/mdbook.html#classwarning). The sections are titled "Developer note", as to indicate this info is particularly relevant for integrators and devs.
- Adds a paragraph on refunds for swap-ins, which looks like this (bottom section) :

<img width="795" alt="Screenshot 2024-01-08 at 19 56 19" src="https://github.com/breez/breez-sdk-docs/assets/106775972/a233e73e-8824-4f44-99db-c01aca94964f">

- For the swap-in page, it merges the "List refundable swaps" section into "Refund Swap", as they are not different sections but rather different steps that go together for the same section.