### PR TITLE
Add developer note for application specific working directories

### DIFF
--- a/src/guide/getting_started.md
+++ b/src/guide/getting_started.md
@@ -107,6 +107,13 @@ Now you are ready to interact with the SDK.
 </section>
 </custom-tabs>
 
+<div class="warning">
+<h4>Developer note</h4>
+
+By default the config working directory is set to `./`. Some platforms may require that you use an application specific directory that is writable within the application sandbox. For example applications running on Android or iOS.
+
+</div>
+
 ## Getting the Node State
 
 At any point we can fetch our balance from the Greenlight node:


### PR DESCRIPTION
Add developer note describing that on certain platforms (e.g. Android / iOS) an application specific directory needs to be used as the config's working directory.

Fixes https://github.com/breez/breez-sdk/issues/713