### PR TITLE
Consolidate "receive payment" snippets

### DIFF
--- a/snippets/csharp/ReceivePayment.cs
+++ b/snippets/csharp/ReceivePayment.cs
@@ -7,8 +7,10 @@ public class ReceivePaymentSnippets
         // ANCHOR: receive-payment
         try
         {
-            var invoice = sdk.ReceivePayment(
+            var receivePaymentResponse = sdk.ReceivePayment(
                 new ReceivePaymentRequest(3_000_000, "Invoice for 3000 sats"));
+
+            var invoice = receivePaymentResponse.lnInvoice;
         }
         catch (Exception)
         {

--- a/snippets/dart_snippets/lib/receive_payment.dart
+++ b/snippets/dart_snippets/lib/receive_payment.dart
@@ -7,8 +7,9 @@ Future<ReceivePaymentResponse> receivePayment() async {
     amountMsat: 3000000,
     description: "Invoice for 3000 sats",
   );
-  ReceivePaymentResponse resp = await BreezSDK().receivePayment(req: req);
-  print(resp.lnInvoice);
+  ReceivePaymentResponse receivePaymentResponse = await BreezSDK().receivePayment(req: req);
+
+  print(receivePaymentResponse.lnInvoice);
   // ANCHOR_END: receive-payment
-  return resp;
+  return receivePaymentResponse;
 }

--- a/snippets/go/receive_payment.go
+++ b/snippets/go/receive_payment.go
@@ -13,7 +13,7 @@ func ReceivePayment() {
 		Description: "Invoice for 3000 sats",
 	}
 	if receivePaymentResponse, err := sdk.ReceivePayment(receivePaymentRequest); err == nil {
-		log.Printf("%#v", receivePaymentResponse)
+		log.Printf("Invoice: %#v", receivePaymentResponse.LnInvoice)
 	}
 	// ANCHOR_END: receive-payment
 }

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
@@ -5,10 +5,12 @@ class ReceivePayment {
     fun receive_payment(sdk: BlockingBreezServices) {
         // ANCHOR: receive-payment
         try {
-            val invoice = sdk.receivePayment(ReceivePaymentRequest(
+            val receivePaymentResponse = sdk.receivePayment(ReceivePaymentRequest(
                 3_000_000.toULong(),
                 "Invoice for 3000 sats",
             ))
+
+            val invoice = receivePaymentResponse.lnInvoice;
         } catch (e: Exception) {
             // handle error
         }

--- a/snippets/python/src/receive_payment.py
+++ b/snippets/python/src/receive_payment.py
@@ -6,10 +6,12 @@ def receive_payment(sdk_services):
         # ANCHOR: receive-payment
         req = breez_sdk.ReceivePaymentRequest(
             amount_msat=3000000,
-            description="Invoice for 3 000 000 sats")
-        result = sdk_services.receive_payment(req)
+            description="Invoice for 3 000 sats")
+        receive_payment_response = sdk_services.receive_payment(req)
+
+        invoice = receive_payment_response.ln_invoice
         # ANCHOR_END: receive-payment
-        return result
+        return receive_payment_response
     except Exception as error:
         print(error)
         raise

--- a/snippets/react-native/receive_payment.ts
+++ b/snippets/react-native/receive_payment.ts
@@ -2,9 +2,11 @@ import { receivePayment } from '@breeztech/react-native-breez-sdk'
 
 const exampleReceiveLightningPayment = async () => {
   // ANCHOR: receive-payment
-  const invoice = await receivePayment({
-    amountMsat: 3000000,
+  const receivePaymentResponse = await receivePayment({
+    amountMsat: 3_000_000,
     description: 'Invoice for 3000 sats'
   })
+
+  const invoice = receivePaymentResponse.lnInvoice
   // ANCHOR_END: receive-payment
 }

--- a/snippets/rust/src/receive_payment.rs
+++ b/snippets/rust/src/receive_payment.rs
@@ -5,13 +5,15 @@ use breez_sdk_core::*;
 
 async fn receive_payment(sdk: Arc<BreezServices>) -> Result<()> {
     // ANCHOR: receive-payment
-    let res = sdk
+    let receive_payment_response = sdk
         .receive_payment(ReceivePaymentRequest {
             amount_msat: 3_000_000,
             description: "Invoice for 3000 sats".into(),
             ..Default::default()
         })
         .await?;
+
+    let invoice = receive_payment_response.ln_invoice;
     // ANCHOR_END: receive-payment
 
     Ok(())

--- a/snippets/swift/BreezSDKExamples/Sources/ReceivePayment.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/ReceivePayment.swift
@@ -9,10 +9,12 @@ import BreezSDK
 
 func receivePayment(sdk: BlockingBreezServices) -> ReceivePaymentResponse? {
     // ANCHOR: receive-payment
-    let repsonse = try? sdk.receivePayment(
+    let receivePaymentResponse = try? sdk.receivePayment(
         req: ReceivePaymentRequest(
             amountMsat: 3_000_000,
-            description: "Invoice for 3 000 000 sats"))
+            description: "Invoice for 3 000 sats"))
+
+    let invoice = receivePaymentResponse?.lnInvoice;
     // ANCHOR_END: receive-payment
-    return repsonse
+    return receivePaymentResponse
 }


### PR DESCRIPTION
This PR consolidates the "receive payment" snippets and exposes the invoice field.

Similar to this, other response fields can be exposed in the future, like the channel opening fee.

Related to #109