### PR TITLE
Fix links when landing at root URL

### DIFF
--- a/snippets/react-native/closed_channel.ts
+++ b/snippets/react-native/closed_channel.ts
@@ -7,7 +7,7 @@ const examplePrepareRedeemOnchainFunds = async (feeRate: number) => {
   // ANCHOR: prepare-redeem-onchain-funds
   try {
     const toAddress = 'bc1..'
-    const satPerVbyte = feeRate  
+    const satPerVbyte = feeRate
     const prepareRedeemOnchainFundsResp = await prepareRedeemOnchainFunds({ toAddress, satPerVbyte })
   } catch (err) {
     console.error(err)

--- a/src/guide/getting_started.md
+++ b/src/guide/getting_started.md
@@ -27,7 +27,7 @@ Join this [telegram group](https://t.me/breezsdk) or email us at <contact@breez.
 
 ## Installing
 
-Breez SDK is available in several platforms. Follow the [Installing](install.md) page for instructions on how to install on your platform.
+Breez SDK is available in several platforms. Follow the [Installing](/guide/install.md) page for instructions on how to install on your platform.
 
 ## Connecting
 
@@ -184,4 +184,4 @@ At any point we can fetch our balance from the Greenlight node:
 </section>
 </custom-tabs>
 
-You are now ready to receive a Lightning [payment](payments.md).
+You are now ready to receive a Lightning [payment](/guide/payments.md).

--- a/src/guide/payment_notification.md
+++ b/src/guide/payment_notification.md
@@ -1,6 +1,6 @@
 # Receiving payments via  mobile notifications 
 
-The Breez SDK provides users the ability to receive Lightning payments via mobile notifications. It uses a webhook that allows your application to be notified (via a pre-specified URL) when a payment is about to be received. To use this feature, you need to set up a webhook that an LSP can call when a payment is received and [register it in the Breez SDK](https://sdk-doc.breez.technology/guide/payment_notification.html#step-3-register-a-webhook). This webhook, a URL endpoint in your application, will handle incoming payment notifications. This URL should be capable of receiving POST requests. The payment received webhook payload is json formatted and contains the following structure:
+The Breez SDK provides users the ability to receive Lightning payments via mobile notifications. It uses a webhook that allows your application to be notified (via a pre-specified URL) when a payment is about to be received. To use this feature, you need to set up a webhook that an LSP can call when a payment is received and [register it in the Breez SDK](payment_notification.html#step-3-register-a-webhook). This webhook, a URL endpoint in your application, will handle incoming payment notifications. This URL should be capable of receiving POST requests. The payment received webhook payload is json formatted and contains the following structure:
 
 <section>
 <pre>


### PR DESCRIPTION
The links in the default page getting_started don't work if landing at https://sdk-doc.breez.technology/