### PR TITLE
Add `prepareOnchainPayment` snippets

### DIFF
--- a/snippets/csharp/SendOnchain.cs
+++ b/snippets/csharp/SendOnchain.cs
@@ -34,6 +34,31 @@ public class SendOnchainSnippets
         // ANCHOR_END: max-reverse-swap-amount
     }
 
+    public void PreparePayOnchain(BlockingBreezServices sdk, OnchainPaymentLimitsResponse currentLimits, uint feeRate)
+    {
+        // ANCHOR: prepare-pay-onchain
+        var amountSat = currentLimits.minSat;
+        var claimTxFeerate = feeRate;
+
+        try
+        {
+            var resp = sdk.PrepareOnchainPayment(
+                new PrepareOnchainPaymentRequest(
+                    amountSat,
+                    SwapAmountType.SEND,
+                    claimTxFeerate));
+
+            Console.WriteLine($"Send amount, in sats: {resp.senderAmountSat}");
+            Console.WriteLine($"Receive amount, in sats: {resp.recipientAmountSat}");
+            Console.WriteLine($"Total fees, in sats: {resp.totalFees}");
+        }
+        catch (Exception)
+        {
+            // Handle error
+        }
+        // ANCHOR_END: prepare-pay-onchain
+    }
+
     public void StartReverseSwap(BlockingBreezServices sdk, ReverseSwapPairInfo currentFees, uint feeRate)
     {
         // ANCHOR: start-reverse-swap

--- a/snippets/csharp/SendOnchain.cs
+++ b/snippets/csharp/SendOnchain.cs
@@ -48,8 +48,8 @@ public class SendOnchainSnippets
                     SwapAmountType.SEND,
                     claimTxFeerate));
 
-            Console.WriteLine($"Send amount, in sats: {resp.senderAmountSat}");
-            Console.WriteLine($"Receive amount, in sats: {resp.recipientAmountSat}");
+            Console.WriteLine($"Sender amount, in sats: {resp.senderAmountSat}");
+            Console.WriteLine($"Recipient amount, in sats: {resp.recipientAmountSat}");
             Console.WriteLine($"Total fees, in sats: {resp.totalFees}");
         }
         catch (Exception)

--- a/snippets/dart_snippets/lib/send_onchain.dart
+++ b/snippets/dart_snippets/lib/send_onchain.dart
@@ -29,8 +29,8 @@ Future<PrepareOnchainPaymentResponse> preparePayOnchain({
     claimTxFeerate: satPerVbyte,
   );
   PrepareOnchainPaymentResponse resp = await BreezSDK().prepareOnchainPayment(req: req);
-  print("Send amount: ${resp.senderAmountSat} sats");
-  print("Receive amount: ${resp.recipientAmountSat} sats");
+  print("Sender amount: ${resp.senderAmountSat} sats");
+  print("Recipient amount: ${resp.recipientAmountSat} sats");
   print("Total fees: ${resp.totalFees} sats");
   // ANCHOR_END: prepare-pay-onchain
   return resp;

--- a/snippets/dart_snippets/lib/send_onchain.dart
+++ b/snippets/dart_snippets/lib/send_onchain.dart
@@ -18,6 +18,24 @@ Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount() async {
   return maxAmount;
 }
 
+Future<PrepareOnchainPaymentResponse> preparePayOnchain({
+  required int amountSat,
+  required int satPerVbyte,
+}) async {
+  // ANCHOR: prepare-pay-onchain
+  PrepareOnchainPaymentRequest req = PrepareOnchainPaymentRequest(
+    amountSat: amountSat,
+    amountType: SwapAmountType.Send,
+    claimTxFeerate: satPerVbyte,
+  );
+  PrepareOnchainPaymentResponse resp = await BreezSDK().prepareOnchainPayment(req: req);
+  print("Send amount: ${resp.senderAmountSat} sats");
+  print("Receive amount: ${resp.recipientAmountSat} sats");
+  print("Total fees: ${resp.totalFees} sats");
+  // ANCHOR_END: prepare-pay-onchain
+  return resp;
+}
+
 Future<SendOnchainResponse> startReverseSwap({
   required int amountSat,
   required String onchainRecipientAddress,

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -23,10 +23,10 @@ func MaxReverseSwapAmount() {
 	// ANCHOR_END: max-reverse-swap-amount
 }
 
-func PreparePayOnchain() {
+func PreparePayOnchain(currentLimits breez_sdk.OnchainPaymentLimitsResponse) {
 	// ANCHOR: prepare-pay-onchain
-	sendAmountSat := uint64(50_000)
-	satPerVbyte := uint32(5)
+	sendAmountSat := currentLimits.MinSat
+	satPerVbyte := uint32(10)
 
 	req := breez_sdk.PrepareOnchainPaymentRequest{
 		AmountSat:               sendAmountSat,

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -23,6 +23,25 @@ func MaxReverseSwapAmount() {
 	// ANCHOR_END: max-reverse-swap-amount
 }
 
+func PreparePayOnchain() {
+	// ANCHOR: prepare-pay-onchain
+	sendAmountSat := uint64(50_000)
+	satPerVbyte := uint32(5)
+
+    req := breez_sdk.PrepareOnchainPaymentRequest{
+        AmountSat:               sendAmountSat,
+        AmountType:              breez_sdk.SwapAmountTypeSend,
+        ClaimTxFeerate:          satPerVbyte,
+    }
+
+	if prepareResp, err := sdk.PrepareOnchainPayment(req); err == nil {
+		log.Printf("Send amount, in sats: %v", prepareResp.SenderAmountSat)
+		log.Printf("Receive amount, in sats: %v", prepareResp.RecipientAmountSat)
+		log.Printf("Total fees, in sats: %v", prepareResp.TotalFees)
+	}
+	// ANCHOR_END: prepare-pay-onchain
+}
+
 func StartReverseSwap() {
 	// ANCHOR: start-reverse-swap
 	destinationAddress := "bc1.."

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -35,8 +35,8 @@ func PreparePayOnchain() {
     }
 
 	if prepareResp, err := sdk.PrepareOnchainPayment(req); err == nil {
-		log.Printf("Send amount, in sats: %v", prepareResp.SenderAmountSat)
-		log.Printf("Receive amount, in sats: %v", prepareResp.RecipientAmountSat)
+		log.Printf("Sender amount, in sats: %v", prepareResp.SenderAmountSat)
+		log.Printf("Recipient amount, in sats: %v", prepareResp.RecipientAmountSat)
 		log.Printf("Total fees, in sats: %v", prepareResp.TotalFees)
 	}
 	// ANCHOR_END: prepare-pay-onchain

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -28,11 +28,11 @@ func PreparePayOnchain() {
 	sendAmountSat := uint64(50_000)
 	satPerVbyte := uint32(5)
 
-    req := breez_sdk.PrepareOnchainPaymentRequest{
-        AmountSat:               sendAmountSat,
-        AmountType:              breez_sdk.SwapAmountTypeSend,
-        ClaimTxFeerate:          satPerVbyte,
-    }
+	req := breez_sdk.PrepareOnchainPaymentRequest{
+		AmountSat:               sendAmountSat,
+		AmountType:              breez_sdk.SwapAmountTypeSend,
+		ClaimTxFeerate:          satPerVbyte,
+	}
 
 	if prepareResp, err := sdk.PrepareOnchainPayment(req); err == nil {
 		log.Printf("Sender amount, in sats: %v", prepareResp.SenderAmountSat)

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -29,9 +29,9 @@ func PreparePayOnchain(currentLimits breez_sdk.OnchainPaymentLimitsResponse) {
 	satPerVbyte := uint32(10)
 
 	req := breez_sdk.PrepareOnchainPaymentRequest{
-		AmountSat:               sendAmountSat,
-		AmountType:              breez_sdk.SwapAmountTypeSend,
-		ClaimTxFeerate:          satPerVbyte,
+		AmountSat:      sendAmountSat,
+		AmountType:     breez_sdk.SwapAmountTypeSend,
+		ClaimTxFeerate: satPerVbyte,
 	}
 
 	if prepareResp, err := sdk.PrepareOnchainPayment(req); err == nil {

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
@@ -32,8 +32,8 @@ class SendOnchain {
         try {
             val prepareRequest = PrepareOnchainPaymentRequest(amountSat, SwapAmountType.SEND, satPerVbyte)
             val prepareRes = sdk.prepareOnchainPayment(prepareRequest)
-            // Log.v("Breez", "Send amount: ${prepareRes.senderAmountSat} sats")
-            // Log.v("Breez", "Receive amount: ${prepareRes.recipientAmountSat} sats")
+            // Log.v("Breez", "Sender amount: ${prepareRes.senderAmountSat} sats")
+            // Log.v("Breez", "Recipient amount: ${prepareRes.recipientAmountSat} sats")
             // Log.v("Breez", "Total fees: ${prepareRes.totalFees} sats")
         } catch (e: Exception) {
             // handle error

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
@@ -25,6 +25,22 @@ class SendOnchain {
         // ANCHOR_END: max-reverse-swap-amount
     }
 
+    fun prepare_pay_onchain(sdk: BlockingBreezServices, currentLimits: OnchainPaymentLimitsResponse) {
+        // ANCHOR: prepare-pay-onchain
+        val amountSat = currentLimits.minSat
+        val satPerVbyte = 10.toUInt()
+        try {
+            val prepareRequest = PrepareOnchainPaymentRequest(amountSat, SwapAmountType.SEND, satPerVbyte)
+            val prepareRes = sdk.prepareOnchainPayment(prepareRequest)
+            // Log.v("Breez", "Send amount: ${prepareRes.senderAmountSat} sats")
+            // Log.v("Breez", "Receive amount: ${prepareRes.recipientAmountSat} sats")
+            // Log.v("Breez", "Total fees: ${prepareRes.totalFees} sats")
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: prepare-pay-onchain
+    }
+
     fun start_reverse_swap(sdk: BlockingBreezServices, fees: ReverseSwapPairInfo) {
         // ANCHOR: start-reverse-swap
         val address = "bc1.."

--- a/snippets/python/src/send_onchain.py
+++ b/snippets/python/src/send_onchain.py
@@ -31,8 +31,8 @@ def prepare_pay_onchain(sdk_services, current_limits, fee_rate):
         req = breez_sdk.PrepareOnchainPaymentRequest(amount_sat, breez_sdk.SwapAmountType.SEND, claim_tx_feerate)
         resp = sdk_services.prepare_onchain_payment(req)
 
-        print("Send amount, in sats: ", resp.sender_amount_sat)
-        print("Receive amount, in sats: ", resp.recipient_amount_sat)
+        print("Sender amount, in sats: ", resp.sender_amount_sat)
+        print("Recipient amount, in sats: ", resp.recipient_amount_sat)
         print("Total fees, in sats: ", resp.total_fees)
     # ANCHOR_END: prepare-pay-onchain
     except Exception as error:

--- a/snippets/python/src/send_onchain.py
+++ b/snippets/python/src/send_onchain.py
@@ -23,6 +23,22 @@ def max_reverse_swap_amount(sdk_services):
         print(error)
         raise
 
+def prepare_pay_onchain(sdk_services, current_limits, fee_rate):
+    amount_sat = current_limits.min_sat
+    claim_tx_feerate = fee_rate
+    try:
+        # ANCHOR: prepare-pay-onchain
+        req = breez_sdk.PrepareOnchainPaymentRequest(amount_sat, breez_sdk.SwapAmountType.SEND, claim_tx_feerate)
+        resp = sdk_services.prepare_onchain_payment(req)
+
+        print("Send amount, in sats: ", resp.sender_amount_sat)
+        print("Receive amount, in sats: ", resp.recipient_amount_sat)
+        print("Total fees, in sats: ", resp.total_fees)
+    # ANCHOR_END: prepare-pay-onchain
+    except Exception as error:
+        print(error)
+        raise
+
 def start_reverse_swap(sdk_services, current_fees,fee_rate):
     # ANCHOR: start-reverse-swap
     destination_address = "bc1.."

--- a/snippets/react-native/send_onchain.ts
+++ b/snippets/react-native/send_onchain.ts
@@ -1,9 +1,12 @@
 import {
   type ReverseSwapPairInfo,
+  type OnchainPaymentLimitsResponse,
   fetchReverseSwapFees,
   inProgressReverseSwaps,
   onchainPaymentLimits,
+  prepareOnchainPayment,
   sendOnchain,
+  SwapAmountType,
   maxReverseSwapAmount
 } from '@breeztech/react-native-breez-sdk'
 
@@ -32,6 +35,26 @@ const maxAmount = async () => {
     console.error(err)
   }
   // ANCHOR_END: max-reverse-swap-amount
+}
+
+const examplePreparePayOnchain = async (currentLimits: OnchainPaymentLimitsResponse) => {
+  // ANCHOR: prepare-pay-onchain
+  try {
+    const amountSat = currentLimits.minSat
+    const satPerVbyte = 10
+
+    const prepareResponse = await prepareOnchainPayment({
+      amountSat,
+      amountType: SwapAmountType.SEND,
+      claimTxFeerate: satPerVbyte
+    })
+    console.log(`Send amount: ${prepareResponse.senderAmountSat} sats`)
+    console.log(`Receive amount: ${prepareResponse.recipientAmountSat} sats`)
+    console.log(`Total fees: ${prepareResponse.totalFees} sats`)
+  } catch (err) {
+    console.error(err)
+  }
+  // ANCHOR_END: prepare-pay-onchain
 }
 
 const exampleSendOnchain = async (currentFees: ReverseSwapPairInfo) => {

--- a/snippets/react-native/send_onchain.ts
+++ b/snippets/react-native/send_onchain.ts
@@ -48,8 +48,8 @@ const examplePreparePayOnchain = async (currentLimits: OnchainPaymentLimitsRespo
       amountType: SwapAmountType.SEND,
       claimTxFeerate: satPerVbyte
     })
-    console.log(`Send amount: ${prepareResponse.senderAmountSat} sats`)
-    console.log(`Receive amount: ${prepareResponse.recipientAmountSat} sats`)
+    console.log(`Sender amount: ${prepareResponse.senderAmountSat} sats`)
+    console.log(`Recipient amount: ${prepareResponse.recipientAmountSat} sats`)
     console.log(`Total fees: ${prepareResponse.totalFees} sats`)
   } catch (err) {
     console.error(err)

--- a/snippets/rust/src/send_onchain.rs
+++ b/snippets/rust/src/send_onchain.rs
@@ -42,8 +42,8 @@ async fn prepare_pay_onchain(
         })
         .await?;
 
-    info!("Send amount: {} sats", prepare_res.sender_amount_sat);
-    info!("Receive amount: {} sats", prepare_res.recipient_amount_sat);
+    info!("Sender amount: {} sats", prepare_res.sender_amount_sat);
+    info!("Recipient amount: {} sats", prepare_res.recipient_amount_sat);
     info!("Total fees: {} sats", prepare_res.total_fees);
     // ANCHOR_END: prepare-pay-onchain
 

--- a/snippets/rust/src/send_onchain.rs
+++ b/snippets/rust/src/send_onchain.rs
@@ -8,8 +8,8 @@ async fn get_current_limits(sdk: Arc<BreezServices>) -> Result<()> {
     // ANCHOR: get-current-reverse-swap-limits
     let current_limits = sdk.onchain_payment_limits().await?;
 
-    info!("Minimum amount, in sats: {}", current_limits.min_sat);
-    info!("Maximum amount, in sats: {}", current_limits.max_sat);
+    info!("Minimum amount: {} sats", current_limits.min_sat);
+    info!("Maximum amount: {} sats", current_limits.max_sat);
     // ANCHOR_END: get-current-reverse-swap-limits
 
     Ok(())
@@ -21,6 +21,31 @@ async fn max_reverse_swap_amount(sdk: Arc<BreezServices>) -> Result<()> {
 
     info!("Max reverse swap amount: {:?}", max_amount.total_sat);
     // ANCHOR_END: max-reverse-swap-amount
+
+    Ok(())
+}
+
+async fn prepare_pay_onchain(
+    sdk: Arc<BreezServices>,
+    current_limits: OnchainPaymentLimitsResponse,
+    fee_rate: u32,
+) -> Result<()> {
+    // ANCHOR: prepare-pay-onchain
+    let amount_sat = current_limits.min_sat;
+    let claim_tx_feerate = fee_rate;
+
+    let prepare_res = sdk
+        .prepare_onchain_payment(PrepareOnchainPaymentRequest {
+            amount_sat,
+            amount_type: SwapAmountType::Send,
+            claim_tx_feerate,
+        })
+        .await?;
+
+    info!("Send amount: {} sats", prepare_res.sender_amount_sat);
+    info!("Receive amount: {} sats", prepare_res.recipient_amount_sat);
+    info!("Total fees: {} sats", prepare_res.total_fees);
+    // ANCHOR_END: prepare-pay-onchain
 
     Ok(())
 }

--- a/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
@@ -33,8 +33,8 @@ func PreparePayOnchain(sdk: BlockingBreezServices, currentLimits: OnchainPayment
     let prepareRequest = PrepareOnchainPaymentRequest(amountSat: amountSat, amountType: .send, claimTxFeerate: satPerVbyte);
     let prepareResponse = try? sdk.prepareOnchainPayment(req: prepareRequest)
 
-    print("Send amount, in sats: \(prepareResponse.senderAmountSat)")
-    print("Receive amount, in sats: \(prepareResponse.recipientAmountSat)")
+    print("Sender amount, in sats: \(prepareResponse.senderAmountSat)")
+    print("Recipient amount, in sats: \(prepareResponse.recipientAmountSat)")
     print("Total fees, in sats: \(prepareResponse.totalFees)")
     // ANCHOR_END: prepare-pay-onchain
     return prepareResponse

--- a/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
@@ -25,6 +25,21 @@ func maxReverseSwapAmount(sdk: BlockingBreezServices) -> MaxReverseSwapAmountRes
     return maxAmount
 }
 
+func PreparePayOnchain(sdk: BlockingBreezServices, currentLimits: OnchainPaymentLimitsResponse) -> PrepareOnchainPaymentResponse? {
+    // ANCHOR: prepare-pay-onchain
+    let amountSat = currentLimits.minSat
+    let satPerVbyte: UInt32 = 5
+
+    let prepareRequest = PrepareOnchainPaymentRequest(amountSat: amountSat, amountType: .send, claimTxFeerate: satPerVbyte);
+    let prepareResponse = try? sdk.prepareOnchainPayment(req: prepareRequest)
+
+    print("Send amount, in sats: \(prepareResponse.senderAmountSat)")
+    print("Receive amount, in sats: \(prepareResponse.recipientAmountSat)")
+    print("Total fees, in sats: \(prepareResponse.totalFees)")
+    // ANCHOR_END: prepare-pay-onchain
+    return prepareResponse
+}
+
 func StartReverseSwap(sdk: BlockingBreezServices, currentFees: ReverseSwapPairInfo) -> SendOnchainResponse? {
     // ANCHOR: start-reverse-swap
     let destinationAddress = "bc1.."

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -85,10 +85,10 @@ It is best to fetch these limits just before your app shows the Pay Onchain (rev
 The next step is to get an overview of the exact amount that will be sent, the amount that will be received, and the fees.
 
 There are two ways to do this:
-- you can set the send amount, then the received amount will be your input minus the fees
-- you can set the receive amount, in which case the send amount will be your input plus the fees
+- you can set the sender amount, then the recipient amount will be your input minus the fees
+- you can set the recipient amount, in which case the sender amount will be your input plus the fees
 
-Assuming you'd like to specify the send amount, the snippet is as follows:
+Assuming you'd like to specify the sender amount, the snippet is as follows:
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
@@ -156,7 +156,7 @@ Assuming you'd like to specify the send amount, the snippet is as follows:
 </section>
 </custom-tabs>
 
-If instead you'd like to specify the receive amount, simply change the `SwapAmountType` from `Send` to `Receive`.
+If instead you'd like to specify the recipient amount, simply change the `SwapAmountType` from `Send` to `Receive`.
 
 Once you checked the amounts and the fees are acceptable, you can continue with sending the payment.
 

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -81,6 +81,85 @@ It is best to fetch these limits just before your app shows the Pay Onchain (rev
 
 </div>
 
+## Preparing to send, checking fees
+The next step is to get an overview of the exact amount that will be sent, the amount that will be received, and the fees.
+
+There are two ways to do this:
+- you can set the send amount, then the received amount will be your input minus the fees
+- you can set the receive amount, in which case the send amount will be your input plus the fees
+
+Assuming you'd like to specify the send amount, the snippet is as follows:
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/send_onchain.rs:prepare-pay-onchain}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift:prepare-pay-onchain}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt:prepare-pay-onchain}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/send_onchain.ts:prepare-pay-onchain}}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/dart_snippets/lib/send_onchain.dart:prepare-pay-onchain}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore
+{{#include ../../snippets/python/src/send_onchain.py:prepare-pay-onchain}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/send_onchain.go:prepare-pay-onchain}}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+```cs,ignore
+{{#include ../../snippets/csharp/SendOnchain.cs:prepare-pay-onchain}}
+```
+</section>
+</custom-tabs>
+
+If instead you'd like to specify the receive amount, simply change the `SwapAmountType` from `Send` to `Receive`.
+
+Once you checked the amounts and the fees are acceptable, you can continue with sending the payment.
+
 ## Sending all funds 
 In case you want to drain your channels you need to know the maximum sendable amount to an on-chain address:
 


### PR DESCRIPTION
Update snippets to reflect https://github.com/breez/breez-sdk/commit/908bed466000617364047c103a8785222f8eedff (latest `main` at the moment).

The relevant code changes are:
- adding a new docs section and code snippet for `prepareOnchainPayment`

Builds on top of #139