### PR TITLE
Consolidate send-all snippet

### DIFF
--- a/snippets/csharp/SendOnchain.cs
+++ b/snippets/csharp/SendOnchain.cs
@@ -18,22 +18,6 @@ public class SendOnchainSnippets
         // ANCHOR_END: get-current-reverse-swap-limits
     }
 
-    public void MaxReverseSwapAmount(BlockingBreezServices sdk)
-    {
-        // ANCHOR: max-reverse-swap-amount
-        try
-        {
-            var maxAmountResponse = sdk.MaxReverseSwapAmount();
-            Console.WriteLine(
-                $"Max reverse swap amount {maxAmountResponse.totalSat}");
-        }
-        catch (Exception)
-        {
-            // Handle error
-        }
-        // ANCHOR_END: max-reverse-swap-amount
-    }
-
     public void PreparePayOnchain(BlockingBreezServices sdk, OnchainPaymentLimitsResponse currentLimits, uint feeRate)
     {
         // ANCHOR: prepare-pay-onchain

--- a/snippets/dart_snippets/lib/send_onchain.dart
+++ b/snippets/dart_snippets/lib/send_onchain.dart
@@ -10,14 +10,6 @@ Future<OnchainPaymentLimitsResponse> getCurrentLimits() async {
   return currentLimits;
 }
 
-Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount() async {
-  // ANCHOR: max-reverse-swap-amount  
-  MaxReverseSwapAmountResponse maxAmount = await BreezSDK().maxReverseSwapAmount();
-  print("Max reverse swap amount: ${maxAmount.totalSat}");
-  // ANCHOR_END: max-reverse-swap-amount
-  return maxAmount;
-}
-
 Future<PrepareOnchainPaymentResponse> preparePayOnchain({
   required int amountSat,
   required int satPerVbyte,

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -15,14 +15,6 @@ func GetCurrentLimits() {
 	// ANCHOR_END: get-current-reverse-swap-limits
 }
 
-func MaxReverseSwapAmount() {
-	// ANCHOR: max-reverse-swap-amount
-	if maxAmount, err := sdk.MaxReverseSwapAmount(); err == nil {
-		log.Printf("Max reverse swap amount: %v", maxAmount.TotalSat)
-	}
-	// ANCHOR_END: max-reverse-swap-amount
-}
-
 func PreparePayOnchain(currentLimits breez_sdk.OnchainPaymentLimitsResponse) {
 	// ANCHOR: prepare-pay-onchain
 	sendAmountSat := currentLimits.MinSat

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
@@ -14,17 +14,6 @@ class SendOnchain {
         // ANCHOR_END: get-current-reverse-swap-limits
     }
 
-    fun max_reverse_swap_amount(sdk: BlockingBreezServices) {
-        // ANCHOR: max-reverse-swap-amount
-        try {
-            val maxAmount = sdk.maxReverseSwapAmount()
-            // Log.v("Breez", "Max reverse swap amount: ${maxAmount.totalSat}")
-        } catch (e: Exception) {
-            // handle error
-        }
-        // ANCHOR_END: max-reverse-swap-amount
-    }
-
     fun prepare_pay_onchain(sdk: BlockingBreezServices, currentLimits: OnchainPaymentLimitsResponse) {
         // ANCHOR: prepare-pay-onchain
         val amountSat = currentLimits.minSat

--- a/snippets/python/src/send_onchain.py
+++ b/snippets/python/src/send_onchain.py
@@ -12,17 +12,6 @@ def get_current_limits(sdk_services):
         print(error)
         raise
 
-def max_reverse_swap_amount(sdk_services):
-    try: 
-        # ANCHOR: max-reverse-swap-amount     
-        max_amount = sdk_services.max_reverse_swap_amount()
-        print("Max reverse swap amount: ", max_amount.totalSat)
-        # ANCHOR_END: max-reverse-swap-amount
-        return max_amount
-    except Exception as error:
-        print(error)
-        raise
-
 def prepare_pay_onchain(sdk_services, current_limits, fee_rate):
     amount_sat = current_limits.min_sat
     claim_tx_feerate = fee_rate

--- a/snippets/react-native/send_onchain.ts
+++ b/snippets/react-native/send_onchain.ts
@@ -23,20 +23,6 @@ const exampleFetchReverseSwapLimits = async () => {
   // ANCHOR_END: get-current-reverse-swap-limits
 }
 
-const maxAmount = async () => {
-  // ANCHOR: max-reverse-swap-amount
-  try {
-    const maxAmount = await maxReverseSwapAmount()
-
-    console.log(
-      `Max reverse swap amount: ${maxAmount.totalSat}`
-    )
-  } catch (err) {
-    console.error(err)
-  }
-  // ANCHOR_END: max-reverse-swap-amount
-}
-
 const examplePreparePayOnchain = async (currentLimits: OnchainPaymentLimitsResponse) => {
   // ANCHOR: prepare-pay-onchain
   try {

--- a/snippets/rust/src/send_onchain.rs
+++ b/snippets/rust/src/send_onchain.rs
@@ -15,16 +15,6 @@ async fn get_current_limits(sdk: Arc<BreezServices>) -> Result<()> {
     Ok(())
 }
 
-async fn max_reverse_swap_amount(sdk: Arc<BreezServices>) -> Result<()> {
-    // ANCHOR: max-reverse-swap-amount
-    let max_amount = sdk.max_reverse_swap_amount().await?;
-
-    info!("Max reverse swap amount: {:?}", max_amount.total_sat);
-    // ANCHOR_END: max-reverse-swap-amount
-
-    Ok(())
-}
-
 async fn prepare_pay_onchain(
     sdk: Arc<BreezServices>,
     current_limits: OnchainPaymentLimitsResponse,

--- a/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
@@ -17,14 +17,6 @@ func GetCurrentLimits(sdk: BlockingBreezServices) -> ReverseSwapPairInfo? {
     return currentFees
 }
 
-func maxReverseSwapAmount(sdk: BlockingBreezServices) -> MaxReverseSwapAmountResponse? {
-    //  ANCHOR: max-reverse-swap-amount
-    let maxAmount = try? sdk.maxReverseSwapAmount()
-    print("Max reverse swap amount: \(String(describing: maxAmount?.totalSat))")
-    // ANCHOR_END: max-reverse-swap-amount
-    return maxAmount
-}
-
 func PreparePayOnchain(sdk: BlockingBreezServices, currentLimits: OnchainPaymentLimitsResponse) -> PrepareOnchainPaymentResponse? {
     // ANCHOR: prepare-pay-onchain
     let amountSat = currentLimits.minSat

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -158,76 +158,10 @@ Assuming you'd like to specify the sender amount, the snippet is as follows:
 
 If instead you'd like to specify the recipient amount, simply change the `SwapAmountType` from `Send` to `Receive`.
 
+In case you want to drain your channels and send the maximum amount possible, you can use the above snippet with `amount_sat` set to `current_limits.max_sat` and `amount_type` as `Send`. 
+
 Once you checked the amounts and the fees are acceptable, you can continue with sending the payment.
 
-## Sending all funds 
-In case you want to drain your channels you need to know the maximum sendable amount to an on-chain address:
-
-<custom-tabs category="lang">
-<div slot="title">Rust</div>
-<section>
-
-```rust,ignore
-{{#include ../../snippets/rust/src/send_onchain.rs:max-reverse-swap-amount}}
-```
-</section>
-
-<div slot="title">Swift</div>
-<section>
-
-```swift,ignore
-{{#include ../../snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift:max-reverse-swap-amount}}
-```
-</section>
-
-<div slot="title">Kotlin</div>
-<section>
-
-```kotlin,ignore
-{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt:max-reverse-swap-amount}}
-```
-</section>
-
-<div slot="title">React Native</div>
-<section>
-
-```typescript
-{{#include ../../snippets/react-native/send_onchain.ts:max-reverse-swap-amount}}
-```
-</section>
-
-<div slot="title">Dart</div>
-<section>
-
-```dart,ignore
-{{#include ../../snippets/dart_snippets/lib/send_onchain.dart:max-reverse-swap-amount}}
-```
-</section>
-
-<div slot="title">Python</div>
-<section>
-
-```python,ignore
-{{#include ../../snippets/python/src/send_onchain.py:max-reverse-swap-amount}}
-```
-</section>
-
-<div slot="title">Go</div>
-<section>
-
-```go,ignore
-{{#include ../../snippets/go/send_onchain.go:max-reverse-swap-amount}}
-```
-</section>
-
-<div slot="title">C#</div>
-<section>
-
-```cs,ignore
-{{#include ../../snippets/csharp/SendOnchain.cs:max-reverse-swap-amount}}
-```
-</section>
-</custom-tabs>
 
 ## Executing the Swap
 


### PR DESCRIPTION
Since the `maxReverseSwapAmount` has been integrated in `onchainPaymentLimits`, the docs section for "Send all" doesn't need a separate snippet anymore.

Instead, it was replaced with a new paragraph that describes how to prepare such a reverse swap.

Builds on top of #141