### PR TITLE
Replace `send_onchain` snippets with `pay_onchain`

### DIFF
--- a/snippets/csharp/SendOnchain.cs
+++ b/snippets/csharp/SendOnchain.cs
@@ -26,15 +26,15 @@ public class SendOnchainSnippets
 
         try
         {
-            var resp = sdk.PrepareOnchainPayment(
+            var prepareRes = sdk.PrepareOnchainPayment(
                 new PrepareOnchainPaymentRequest(
                     amountSat,
                     SwapAmountType.SEND,
                     claimTxFeerate));
 
-            Console.WriteLine($"Sender amount, in sats: {resp.senderAmountSat}");
-            Console.WriteLine($"Recipient amount, in sats: {resp.recipientAmountSat}");
-            Console.WriteLine($"Total fees, in sats: {resp.totalFees}");
+            Console.WriteLine($"Sender amount, in sats: {prepareRes.senderAmountSat}");
+            Console.WriteLine($"Recipient amount, in sats: {prepareRes.recipientAmountSat}");
+            Console.WriteLine($"Total fees, in sats: {prepareRes.totalFees}");
         }
         catch (Exception)
         {
@@ -43,20 +43,14 @@ public class SendOnchainSnippets
         // ANCHOR_END: prepare-pay-onchain
     }
 
-    public void StartReverseSwap(BlockingBreezServices sdk, ReverseSwapPairInfo currentFees, uint feeRate)
+    public void StartReverseSwap(BlockingBreezServices sdk, PrepareOnchainPaymentResponse prepareRes)
     {
         // ANCHOR: start-reverse-swap
         var destinationAddress = "bc1..";
-        var amountSat = currentFees.min;
-        var satPerVbyte = feeRate;
         try
         {
-            var reverseSwapInfo = sdk.SendOnchain(
-                new SendOnchainRequest(
-                    amountSat,
-                    destinationAddress,
-                    currentFees.feesHash,
-                    satPerVbyte));
+            var reverseSwapInfo = sdk.PayOnchain(
+                new PayOnchainRequest(destinationAddress, prepareRes));
         }
         catch (Exception)
         {

--- a/snippets/dart_snippets/lib/send_onchain.dart
+++ b/snippets/dart_snippets/lib/send_onchain.dart
@@ -28,7 +28,7 @@ Future<PrepareOnchainPaymentResponse> preparePayOnchain({
   return prepareRes;
 }
 
-Future<SendOnchainResponse> startReverseSwap({
+Future<PayOnchainResponse> startReverseSwap({
   required String onchainRecipientAddress,
   required PrepareOnchainPaymentResponse prepareRes,
 }) async {

--- a/snippets/dart_snippets/lib/send_onchain.dart
+++ b/snippets/dart_snippets/lib/send_onchain.dart
@@ -20,28 +20,24 @@ Future<PrepareOnchainPaymentResponse> preparePayOnchain({
     amountType: SwapAmountType.Send,
     claimTxFeerate: satPerVbyte,
   );
-  PrepareOnchainPaymentResponse resp = await BreezSDK().prepareOnchainPayment(req: req);
-  print("Sender amount: ${resp.senderAmountSat} sats");
-  print("Recipient amount: ${resp.recipientAmountSat} sats");
-  print("Total fees: ${resp.totalFees} sats");
+  PrepareOnchainPaymentResponse prepareRes = await BreezSDK().prepareOnchainPayment(req: req);
+  print("Sender amount: ${prepareRes.senderAmountSat} sats");
+  print("Recipient amount: ${prepareRes.recipientAmountSat} sats");
+  print("Total fees: ${prepareRes.totalFees} sats");
   // ANCHOR_END: prepare-pay-onchain
   return resp;
 }
 
 Future<SendOnchainResponse> startReverseSwap({
-  required int amountSat,
   required String onchainRecipientAddress,
-  required String pairHash,
-  required int satPerVbyte,
+  required PrepareOnchainPaymentResponse prepareRes,
 }) async {
   // ANCHOR: start-reverse-swap
-  SendOnchainRequest req = SendOnchainRequest(
-    amountSat: amountSat,
-    onchainRecipientAddress: onchainRecipientAddress,
-    pairHash: pairHash,
-    satPerVbyte: satPerVbyte,
+  PayOnchainRequest req = PayOnchainRequest(
+    recipientAddress: onchainRecipientAddress,
+    prepareRes: prepareRes,
   );
-  SendOnchainResponse resp = await BreezSDK().sendOnchain(req: req);
+  PayOnchainResponse res = await BreezSDK().payOnchain(req: req);
   // ANCHOR_END: start-reverse-swap
   return resp;
 }

--- a/snippets/dart_snippets/lib/send_onchain.dart
+++ b/snippets/dart_snippets/lib/send_onchain.dart
@@ -39,7 +39,7 @@ Future<SendOnchainResponse> startReverseSwap({
   );
   PayOnchainResponse res = await BreezSDK().payOnchain(req: req);
   // ANCHOR_END: start-reverse-swap
-  return resp;
+  return res;
 }
 
 Future<List<ReverseSwapInfo>> checkReverseSwapStatus() async {

--- a/snippets/dart_snippets/lib/send_onchain.dart
+++ b/snippets/dart_snippets/lib/send_onchain.dart
@@ -25,7 +25,7 @@ Future<PrepareOnchainPaymentResponse> preparePayOnchain({
   print("Recipient amount: ${prepareRes.recipientAmountSat} sats");
   print("Total fees: ${prepareRes.totalFees} sats");
   // ANCHOR_END: prepare-pay-onchain
-  return resp;
+  return prepareRes;
 }
 
 Future<SendOnchainResponse> startReverseSwap({

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -26,29 +26,25 @@ func PreparePayOnchain(currentLimits breez_sdk.OnchainPaymentLimitsResponse) {
 		ClaimTxFeerate: satPerVbyte,
 	}
 
-	if prepareResp, err := sdk.PrepareOnchainPayment(req); err == nil {
-		log.Printf("Sender amount, in sats: %v", prepareResp.SenderAmountSat)
-		log.Printf("Recipient amount, in sats: %v", prepareResp.RecipientAmountSat)
-		log.Printf("Total fees, in sats: %v", prepareResp.TotalFees)
+	if prepareRes, err := sdk.PrepareOnchainPayment(req); err == nil {
+		log.Printf("Sender amount, in sats: %v", prepareRes.SenderAmountSat)
+		log.Printf("Recipient amount, in sats: %v", prepareRes.RecipientAmountSat)
+		log.Printf("Total fees, in sats: %v", prepareRes.TotalFees)
 	}
 	// ANCHOR_END: prepare-pay-onchain
 }
 
-func StartReverseSwap() {
+func StartReverseSwap(prepareRes breez_sdk.PrepareOnchainPaymentResponse) {
 	// ANCHOR: start-reverse-swap
 	destinationAddress := "bc1.."
-	sendAmountSat := uint64(50_000)
-	satPerVbyte := uint32(5)
-	if currentFees, err := sdk.FetchReverseSwapFees(breez_sdk.ReverseSwapFeesRequest{SendAmountSat: &sendAmountSat}); err == nil {
-		sendOnchainRequest := breez_sdk.SendOnchainRequest{
-			AmountSat:               sendAmountSat,
-			OnchainRecipientAddress: destinationAddress,
-			PairHash:                currentFees.FeesHash,
-			SatPerVbyte:             satPerVbyte,
-		}
-		if reverseSwapInfo, err := sdk.SendOnchain(sendOnchainRequest); err == nil {
-			log.Printf("%#v", reverseSwapInfo)
-		}
+
+	payOnchainRequest := breez_sdk.PayOnchainRequest{
+		RecipientAddress:   destinationAddress,
+		PrepareRes:         prepareRes,
+	}
+
+	if reverseSwapInfo, err := sdk.PayOnchain(payOnchainRequest); err == nil {
+		log.Printf("%#v", reverseSwapInfo)
 	}
 	// ANCHOR_END: start-reverse-swap
 }

--- a/snippets/go/send_onchain.go
+++ b/snippets/go/send_onchain.go
@@ -39,8 +39,8 @@ func StartReverseSwap(prepareRes breez_sdk.PrepareOnchainPaymentResponse) {
 	destinationAddress := "bc1.."
 
 	payOnchainRequest := breez_sdk.PayOnchainRequest{
-		RecipientAddress:   destinationAddress,
-		PrepareRes:         prepareRes,
+		RecipientAddress: destinationAddress,
+		PrepareRes:       prepareRes,
 	}
 
 	if reverseSwapInfo, err := sdk.PayOnchain(payOnchainRequest); err == nil {

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendOnchain.kt
@@ -30,13 +30,11 @@ class SendOnchain {
         // ANCHOR_END: prepare-pay-onchain
     }
 
-    fun start_reverse_swap(sdk: BlockingBreezServices, fees: ReverseSwapPairInfo) {
+    fun start_reverse_swap(sdk: BlockingBreezServices, prepareRes: PrepareOnchainPaymentResponse) {
         // ANCHOR: start-reverse-swap
         val address = "bc1.."
-        val amountSat = 123.toULong()
-        val satPerVbyte = 1.toUInt()
         try {
-            sdk.sendOnchain(SendOnchainRequest(amountSat, address, fees.feesHash, satPerVbyte))
+            sdk.payOnchain(PayOnchainRequest(address, prepareRes))
         } catch (e: Exception) {
             // handle error
         }

--- a/snippets/python/src/send_onchain.py
+++ b/snippets/python/src/send_onchain.py
@@ -18,24 +18,22 @@ def prepare_pay_onchain(sdk_services, current_limits, fee_rate):
     try:
         # ANCHOR: prepare-pay-onchain
         req = breez_sdk.PrepareOnchainPaymentRequest(amount_sat, breez_sdk.SwapAmountType.SEND, claim_tx_feerate)
-        resp = sdk_services.prepare_onchain_payment(req)
+        prepare_res = sdk_services.prepare_onchain_payment(req)
 
-        print("Sender amount, in sats: ", resp.sender_amount_sat)
-        print("Recipient amount, in sats: ", resp.recipient_amount_sat)
-        print("Total fees, in sats: ", resp.total_fees)
+        print("Sender amount, in sats: ", prepare_res.sender_amount_sat)
+        print("Recipient amount, in sats: ", prepare_res.recipient_amount_sat)
+        print("Total fees, in sats: ", prepare_res.total_fees)
     # ANCHOR_END: prepare-pay-onchain
     except Exception as error:
         print(error)
         raise
 
-def start_reverse_swap(sdk_services, current_fees,fee_rate):
+def start_reverse_swap(sdk_services, prepare_res):
     # ANCHOR: start-reverse-swap
     destination_address = "bc1.."
-    amount_sat = 50000
-    sat_per_vbyte = fee_rate
     try:
-        req = breez_sdk.SendOnchainRequest(amount_sat, destination_address, current_fees.fees_hash, sat_per_vbyte)
-        sdk_services.send_onchain(req)
+        req = breez_sdk.PayOnchainRequest(destination_address, prepare_res)
+        sdk_services.pay_onchain(req)
     # ANCHOR_END: start-reverse-swap
     except Exception as error:
         print(error)

--- a/snippets/python/src/send_onchain.py
+++ b/snippets/python/src/send_onchain.py
@@ -7,7 +7,7 @@ def get_current_limits(sdk_services):
         print("Minimum amount, in sats: ", current_limits.min_sat)
         print("Maximum amount, in sats: ", current_limits.max_sat)
         # ANCHOR_END: get-current-reverse-swap-limits
-        return current_fees
+        return current_limits
     except Exception as error:
         print(error)
         raise

--- a/snippets/react-native/send_onchain.ts
+++ b/snippets/react-native/send_onchain.ts
@@ -43,7 +43,7 @@ const examplePreparePayOnchain = async (currentLimits: OnchainPaymentLimitsRespo
   // ANCHOR_END: prepare-pay-onchain
 }
 
-const examplePayOnchain = async (prepareResponse: PrepareOnchainPaymentResponse) => {
+const examplePayOnchain = async (prepareRes: PrepareOnchainPaymentResponse) => {
   // ANCHOR: start-reverse-swap
   try {
     const onchainRecipientAddress = 'bc1..'

--- a/snippets/react-native/send_onchain.ts
+++ b/snippets/react-native/send_onchain.ts
@@ -43,18 +43,14 @@ const examplePreparePayOnchain = async (currentLimits: OnchainPaymentLimitsRespo
   // ANCHOR_END: prepare-pay-onchain
 }
 
-const exampleSendOnchain = async (currentFees: ReverseSwapPairInfo) => {
+const examplePayOnchain = async (prepareResponse: PrepareOnchainPaymentResponse) => {
   // ANCHOR: start-reverse-swap
   try {
     const onchainRecipientAddress = 'bc1..'
-    const amountSat = currentFees.min
-    const satPerVbyte = 5
 
-    const reverseSwapInfo = await sendOnchain({
-      amountSat,
-      onchainRecipientAddress,
-      pairHash: currentFees.feesHash,
-      satPerVbyte
+    const reverseSwapInfo = await payOnchain({
+      recipientAddress: onchainRecipientAddress,
+      prepareResponse
     })
   } catch (err) {
     console.error(err)

--- a/snippets/react-native/send_onchain.ts
+++ b/snippets/react-native/send_onchain.ts
@@ -1,11 +1,11 @@
 import {
-  type ReverseSwapPairInfo,
   type OnchainPaymentLimitsResponse,
+  type PrepareOnchainPaymentResponse,
   fetchReverseSwapFees,
   inProgressReverseSwaps,
   onchainPaymentLimits,
+  payOnchain,
   prepareOnchainPayment,
-  sendOnchain,
   SwapAmountType,
   maxReverseSwapAmount
 } from '@breeztech/react-native-breez-sdk'

--- a/snippets/react-native/send_onchain.ts
+++ b/snippets/react-native/send_onchain.ts
@@ -50,7 +50,7 @@ const examplePayOnchain = async (prepareRes: PrepareOnchainPaymentResponse) => {
 
     const reverseSwapInfo = await payOnchain({
       recipientAddress: onchainRecipientAddress,
-      prepareResponse
+      prepareRes
     })
   } catch (err) {
     console.error(err)

--- a/snippets/rust/src/send_onchain.rs
+++ b/snippets/rust/src/send_onchain.rs
@@ -33,7 +33,10 @@ async fn prepare_pay_onchain(
         .await?;
 
     info!("Sender amount: {} sats", prepare_res.sender_amount_sat);
-    info!("Recipient amount: {} sats", prepare_res.recipient_amount_sat);
+    info!(
+        "Recipient amount: {} sats",
+        prepare_res.recipient_amount_sat
+    );
     info!("Total fees: {} sats", prepare_res.total_fees);
     // ANCHOR_END: prepare-pay-onchain
 
@@ -42,19 +45,14 @@ async fn prepare_pay_onchain(
 
 async fn start_reverse_swap(
     sdk: Arc<BreezServices>,
-    current_fees: ReverseSwapPairInfo,
-    fee_rate: u32,
+    prepare_res: PrepareOnchainPaymentResponse,
 ) -> Result<()> {
     // ANCHOR: start-reverse-swap
     let destination_address = String::from("bc1..");
-    let amount_sat = current_fees.min;
-    let sat_per_vbyte = fee_rate;
 
-    sdk.send_onchain(SendOnchainRequest {
-        pair_hash: current_fees.fees_hash,
-        amount_sat,
-        sat_per_vbyte,
-        onchain_recipient_address: destination_address,
+    sdk.pay_onchain(PayOnchainRequest {
+        recipient_address: destination_address,
+        prepare_res,
     })
     .await?;
     // ANCHOR_END: start-reverse-swap

--- a/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/SendOnchain.swift
@@ -32,13 +32,11 @@ func PreparePayOnchain(sdk: BlockingBreezServices, currentLimits: OnchainPayment
     return prepareResponse
 }
 
-func StartReverseSwap(sdk: BlockingBreezServices, currentFees: ReverseSwapPairInfo) -> SendOnchainResponse? {
+func StartReverseSwap(sdk: BlockingBreezServices, prepareResponse: PrepareOnchainPaymentRequest) -> SendOnchainResponse? {
     // ANCHOR: start-reverse-swap
     let destinationAddress = "bc1.."
-    let amountSat = currentFees.min
-    let satPerVbyte: UInt32 = 5
 
-    let response = try? sdk.sendOnchain(req: SendOnchainRequest(amountSat: amountSat, onchainRecipientAddress: destinationAddress, pairHash: currentFees.feesHash, satPerVbyte: satPerVbyte))
+    let response = try? sdk.payOnchain(req: PayOnchainRequest(recipientAddress: destinationAddress, prepareRes: prepareResponse))
     // ANCHOR_END: start-reverse-swap
     return response
 }

--- a/src/guide/send_onchain.md
+++ b/src/guide/send_onchain.md
@@ -158,14 +158,14 @@ Assuming you'd like to specify the sender amount, the snippet is as follows:
 
 If instead you'd like to specify the recipient amount, simply change the `SwapAmountType` from `Send` to `Receive`.
 
-In case you want to drain your channels and send the maximum amount possible, you can use the above snippet with `amount_sat` set to `current_limits.max_sat` and `amount_type` as `Send`. 
-
-Once you checked the amounts and the fees are acceptable, you can continue with sending the payment.
+In case you want to drain your channels and send the maximum amount possible, you can use the above snippet with `amount_sat` set to `current_limits.max_sat` and `amount_type` as `Send`.
 
 
 ## Executing the Swap
 
-Once you decided about the amount and checked the fees are acceptable, you can start the reverse swap:
+Once you checked the amounts and the fees are acceptable, you can continue with sending the payment.
+
+Note that one of the arguments will be the result from the `prepare` call above.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
@@ -233,13 +233,13 @@ Once you decided about the amount and checked the fees are acceptable, you can s
 </section>
 </custom-tabs>
 
-Starting the reverse swap will trigger a HODL invoice payment, which will only be settled if the entire swap completes.
+Starting the onchain payment (reverse swap) will trigger a HODL invoice payment, which will only be settled if the entire swap completes.
 This means you will see an outgoing pending payment in your list of payments, which locks those funds until the invoice
 is either settled or cancelled. This will happen automatically at the end of the reverse swap.
 
 ## List in-progress Swaps
 
-You can check its status with:
+You can check the ongoing onchain payments (reverse swaps) and their status with:
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>


### PR DESCRIPTION
This PR replaces the old `send_onchain` call in snippets with `pay_onchain`.