### PR TITLE
Use a single instance of BreezSDK on Dart snippets

### DIFF
--- a/snippets/dart_snippets/bin/dart_snippets.dart
+++ b/snippets/dart_snippets/bin/dart_snippets.dart
@@ -1,5 +1,5 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 
 void main(List<String> arguments) {
-  BreezSDK().initialize();
+  breezSDK.initialize();
 }

--- a/snippets/dart_snippets/lib/buy_btc.dart
+++ b/snippets/dart_snippets/lib/buy_btc.dart
@@ -1,10 +1,10 @@
-import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_sdk/bridge_generated.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 
 Future<BuyBitcoinResponse> buyBitcoin() async {
   // ANCHOR: buy-btc
   BuyBitcoinRequest req = const BuyBitcoinRequest(provider: BuyBitcoinProvider.Moonpay);
-  BuyBitcoinResponse resp = await BreezSDK().buyBitcoin(req: req);
+  BuyBitcoinResponse resp = await breezSDK.buyBitcoin(req: req);
   // ANCHOR_END: buy-btc
   return resp;
 }

--- a/snippets/dart_snippets/lib/closed_channel.dart
+++ b/snippets/dart_snippets/lib/closed_channel.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<PrepareRedeemOnchainFundsResponse> prepareRedeemOnchainFunds(
@@ -8,7 +8,7 @@ Future<PrepareRedeemOnchainFundsResponse> prepareRedeemOnchainFunds(
     toAddress: "bc1..",
     satPerVbyte: satPerVbyte,
   );
-  final resp = await BreezSDK().prepareRedeemOnchainFunds(req: req);
+  final resp = await breezSDK.prepareRedeemOnchainFunds(req: req);
   // ANCHOR_END: prepare-redeem-onchain-funds
   return resp;
 }
@@ -20,7 +20,7 @@ Future<RedeemOnchainFundsResponse> redeemOnchainFunds(
     toAddress: "bc1..",
     satPerVbyte: satPerVbyte,
   );
-  final resp = await BreezSDK().redeemOnchainFunds(req: req);
+  final resp = await breezSDK.redeemOnchainFunds(req: req);
   // ANCHOR_END: redeem-onchain-funds
   return resp;
 }

--- a/snippets/dart_snippets/lib/communicating_fees.dart
+++ b/snippets/dart_snippets/lib/communicating_fees.dart
@@ -1,13 +1,13 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> getFeeInfoBeforeInvoiceCreated() async {
   // ANCHOR: get-fee-info-before-receiving-payment
-  NodeState? nodeInfo = await BreezSDK().nodeInfo();
+  NodeState? nodeInfo = await breezSDK.nodeInfo();
   if (nodeInfo != null) {
     int inboundLiquiditySat = nodeInfo.inboundLiquidityMsats ~/ 1000;
 
-    OpenChannelFeeResponse openingFeeResponse = await BreezSDK().openChannelFee(req: OpenChannelFeeRequest());
+    OpenChannelFeeResponse openingFeeResponse = await breezSDK.openChannelFee(req: OpenChannelFeeRequest());
 
     OpeningFeeParams openingFees = openingFeeResponse.feeParams;
     double feePercentage = (openingFees.proportional * 100) / 1000000;
@@ -31,12 +31,12 @@ Future<void> getFeeInfoAfterInvoiceCreated({required ReceivePaymentResponse rece
 
 Future<void> getFeeInfoReceiveOnchain() async {
   // ANCHOR: get-fee-info-receive-onchain
-  SwapInfo swapInfo = await BreezSDK().receiveOnchain(req: ReceiveOnchainRequest());
+  SwapInfo swapInfo = await breezSDK.receiveOnchain(req: ReceiveOnchainRequest());
 
   int minDepositSat = swapInfo.minAllowedDeposit;
   int maxDepositSat = swapInfo.maxAllowedDeposit;
 
-  NodeState? nodeInfo = await BreezSDK().nodeInfo();
+  NodeState? nodeInfo = await breezSDK.nodeInfo();
   if (nodeInfo != null) {
     int inboundLiquiditySat = nodeInfo.inboundLiquidityMsats ~/ 1000;
 

--- a/snippets/dart_snippets/lib/connecting_lsp.dart
+++ b/snippets/dart_snippets/lib/connecting_lsp.dart
@@ -1,10 +1,10 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> getLspInfo() async {
   // ANCHOR: get-lsp-info
-  String? lspId = await BreezSDK().lspId();
-  LspInformation? lspInfo = await BreezSDK().lspInfo();
+  String? lspId = await breezSDK.lspId();
+  LspInformation? lspInfo = await breezSDK.lspInfo();
   print(lspId);
   print(lspInfo);
   // ANCHOR_END: get-lsp-info
@@ -12,13 +12,13 @@ Future<void> getLspInfo() async {
 
 Future<List<LspInformation>> listLsps() async {
   // ANCHOR: list-lsps
-  List<LspInformation> availableLsps = await BreezSDK().listLsps();
+  List<LspInformation> availableLsps = await breezSDK.listLsps();
   // ANCHOR_END: list-lsps
   return availableLsps;
 }
 
 Future<void> connectLsp(String lspId) async {
   // ANCHOR: connect-lsp
-  await BreezSDK().connectLSP(lspId);
+  await breezSDK.connectLSP(lspId);
   // ANCHOR_END: connect-lsp
 }

--- a/snippets/dart_snippets/lib/fiat_currencies.dart
+++ b/snippets/dart_snippets/lib/fiat_currencies.dart
@@ -1,16 +1,16 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<List<FiatCurrency>> listFiatCurrencies() async {
   // ANCHOR: list-fiat-currencies
-  List<FiatCurrency> fiatCurrencyList = await BreezSDK().listFiatCurrencies();
+  List<FiatCurrency> fiatCurrencyList = await breezSDK.listFiatCurrencies();
   // ANCHOR_END: list-fiat-currencies
   return fiatCurrencyList;
 }
 
 Future<Map<String, Rate>> fetchFiatRates(String lspId) async {
   // ANCHOR: fetch-fiat-rates
-  Map<String, Rate> fiatRatesMap = await BreezSDK().fetchFiatRates();
+  Map<String, Rate> fiatRatesMap = await breezSDK.fetchFiatRates();
   // print your desired rate
   print(fiatRatesMap["USD"]?.value);
   // ANCHOR_END: fetch-fiat-rates

--- a/snippets/dart_snippets/lib/getting_started.dart
+++ b/snippets/dart_snippets/lib/getting_started.dart
@@ -1,16 +1,27 @@
 import 'dart:typed_data';
 
 import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> initializeSDK() async {
   // ANCHOR: init-sdk
 
-  // Initialize SDK logs listener
-  BreezSDK().initialize();
+  // It is recommended to use a single instance of BreezSDK across your Dart/Flutter app.
+  //
+  // All of the snippets assume a BreezSDK object is created on entrypoint of the app as such:
+  //
+  // BreezSDK breezSDK = BreezSDK();
+  //
+  // and is accessible throughout the app. There are various approaches on how to achieve this; creating a Singleton class using factory constructor, using state management libraries such as 'provider', 'GetX', 'Riverpod' and 'Redux' to name a few.
+
+  // Initializes SDK events & log streams.
+  //
+  // Call once on your Dart entrypoint file, e.g.; `lib/main.dart`.
+  breezSDK.initialize();
 
   // Create the default config
-  Uint8List seed = await BreezSDK().mnemonicToSeed("<mnemonic words>");
+  Uint8List seed = await breezSDK.mnemonicToSeed("<mnemonic words>");
   String inviteCode = "<invite code>";
   String apiKey = "<api key>";
   NodeConfig nodeConfig = NodeConfig.greenlight(
@@ -19,7 +30,7 @@ Future<void> initializeSDK() async {
       inviteCode: inviteCode,
     ),
   );
-  Config config = await BreezSDK().defaultConfig(
+  Config config = await breezSDK.defaultConfig(
     envType: EnvironmentType.Production,
     apiKey: apiKey,
     nodeConfig: nodeConfig,
@@ -30,20 +41,20 @@ Future<void> initializeSDK() async {
 
   // Connect to the Breez SDK make it ready for use
   ConnectRequest connectRequest = ConnectRequest(config: config, seed: seed);
-  return await BreezSDK().connect(req: connectRequest);
+  return await breezSDK.connect(req: connectRequest);
   // ANCHOR_END: init-sdk
 }
 
 Future<void> connectRestoreOnly(Config config, Uint8List seed) async {
   // ANCHOR: init-sdk-restore-only
   ConnectRequest connectRequest = ConnectRequest(config: config, seed: seed, restoreOnly: true);
-  return await BreezSDK().connect(req: connectRequest);
+  return await breezSDK.connect(req: connectRequest);
   // ANCHOR_END: init-sdk-restore-only
 }
 
 Future<void> fetchBalance(String lspId) async {
   // ANCHOR: fetch-balance
-  NodeState? nodeInfo = await BreezSDK().nodeInfo();
+  NodeState? nodeInfo = await breezSDK.nodeInfo();
   if (nodeInfo != null) {
     int lnBalance = nodeInfo.channelsBalanceMsat;
     int onchainBalance = nodeInfo.onchainBalanceMsat;

--- a/snippets/dart_snippets/lib/list_payments.dart
+++ b/snippets/dart_snippets/lib/list_payments.dart
@@ -1,10 +1,10 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<List<Payment>> listPayments() async {
   // ANCHOR: list-payments
   ListPaymentsRequest req = ListPaymentsRequest();
-  List<Payment> paymentsList = await BreezSDK().listPayments(req: req);
+  List<Payment> paymentsList = await breezSDK.listPayments(req: req);
   print(paymentsList);
   // ANCHOR_END: list-payments
   return paymentsList;
@@ -29,7 +29,7 @@ Future<List<Payment>> listPaymentsFiltered({
     offset: offset,
     limit: limit,
   );
-  List<Payment> paymentsList = await BreezSDK().listPayments(req: req);
+  List<Payment> paymentsList = await breezSDK.listPayments(req: req);
   print(paymentsList);
   // ANCHOR_END: list-payments-filtered
   return paymentsList;

--- a/snippets/dart_snippets/lib/lnurl_auth.dart
+++ b/snippets/dart_snippets/lib/lnurl_auth.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> lnurlAuth() async {
@@ -8,9 +8,9 @@ Future<void> lnurlAuth() async {
   String lnurlAuthUrl =
       "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4excttvdankjm3lw3skw0tvdankjm3xdvcn6vtp8q6n2dfsx5mrjwtrxdjnqvtzv56rzcnyv3jrxv3sxqmkyenrvv6kve3exv6nqdtyv43nqcmzvdsnvdrzx33rsenxx5unqc3cxgeqgntfgu";
 
-  InputType inputType = await BreezSDK().parseInput(input: lnurlAuthUrl);
+  InputType inputType = await breezSDK.parseInput(input: lnurlAuthUrl);
   if (inputType is InputType_LnUrlAuth) {
-    LnUrlCallbackStatus result = await BreezSDK().lnurlAuth(reqData: inputType.data);
+    LnUrlCallbackStatus result = await breezSDK.lnurlAuth(reqData: inputType.data);
     if (result is LnUrlCallbackStatus_Ok) {
       print("Successfully authenticated");
     } else {

--- a/snippets/dart_snippets/lib/lnurl_pay.dart
+++ b/snippets/dart_snippets/lib/lnurl_pay.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> lnurlPay() async {
@@ -8,7 +8,7 @@ Future<void> lnurlPay() async {
   /// lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4excttsv9un7um9wdekjmmw84jxywf5x43rvv35xgmr2enrxanr2cfcvsmnwe3jxcukvde48qukgdec89snwde3vfjxvepjxpjnjvtpxd3kvdnxx5crxwpjvyunsephsz36jf
   String lnurlPayUrl = "lightning@address.com";
 
-  InputType inputType = await BreezSDK().parseInput(input: lnurlPayUrl);
+  InputType inputType = await breezSDK.parseInput(input: lnurlPayUrl);
   if (inputType is InputType_LnUrlPay) {
     int amountMsat = inputType.data.minSendable;
     String optionalComment = "<comment>";
@@ -19,7 +19,7 @@ Future<void> lnurlPay() async {
       comment: optionalComment,
       paymentLabel: optionalPaymentLabel,
     );
-    LnUrlPayResult result = await BreezSDK().lnurlPay(req: req);
+    LnUrlPayResult result = await breezSDK.lnurlPay(req: req);
     print(result.data);
   }
   // ANCHOR_END: lnurl-pay

--- a/snippets/dart_snippets/lib/lnurl_withdraw.dart
+++ b/snippets/dart_snippets/lib/lnurl_withdraw.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> lnurlWithdraw() async {
@@ -8,7 +8,7 @@ Future<void> lnurlWithdraw() async {
   String lnurlWithdrawUrl =
       "lnurl1dp68gurn8ghj7mr0vdskc6r0wd6z7mrww4exctthd96xserjv9mn7um9wdekjmmw843xxwpexdnxzen9vgunsvfexq6rvdecx93rgdmyxcuxverrvcursenpxvukzv3c8qunsdecx33nzwpnvg6ryc3hv93nzvecxgcxgwp3h33lxk";
 
-  InputType inputType = await BreezSDK().parseInput(input: lnurlWithdrawUrl);
+  InputType inputType = await breezSDK.parseInput(input: lnurlWithdrawUrl);
   if (inputType is InputType_LnUrlWithdraw) {
     int amountMsat = inputType.data.minWithdrawable;
     LnUrlWithdrawRequest req = LnUrlWithdrawRequest(
@@ -16,7 +16,7 @@ Future<void> lnurlWithdraw() async {
       amountMsat: amountMsat,
       description: "<description>",
     );
-    LnUrlWithdrawResult result = await BreezSDK().lnurlWithdraw(req: req);
+    LnUrlWithdrawResult result = await breezSDK.lnurlWithdraw(req: req);
     print(result.data);
   }
   // ANCHOR_END: lnurl-withdraw

--- a/snippets/dart_snippets/lib/metadata.dart
+++ b/snippets/dart_snippets/lib/metadata.dart
@@ -1,9 +1,9 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> setPaymentMetadata({required String paymentHash, required String metadata}) async {
   // ANCHOR: set-payment-metadata
-  await BreezSDK().setPaymentMetadata(hash: "target-payment-hash", metadata: '{"myCustomValue":true}');
+  await breezSDK.setPaymentMetadata(hash: "target-payment-hash", metadata: '{"myCustomValue":true}');
   // ANCHOR_END: set-payment-metadata
 }
 
@@ -16,7 +16,7 @@ Future<void> filterPaymentMetadata() async {
     ),
   ];
 
-  await BreezSDK().listPayments(
+  await breezSDK.listPayments(
     req: ListPaymentsRequest(
       metadataFilters: metadataFilters
     ));

--- a/snippets/dart_snippets/lib/pay_onchain.dart
+++ b/snippets/dart_snippets/lib/pay_onchain.dart
@@ -1,9 +1,9 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<OnchainPaymentLimitsResponse> getCurrentLimits() async {
   // ANCHOR: get-current-reverse-swap-limits
-  OnchainPaymentLimitsResponse currentLimits = await BreezSDK().onchainPaymentLimits();
+  OnchainPaymentLimitsResponse currentLimits = await breezSDK.onchainPaymentLimits();
   print("Minimum amount, in sats: ${currentLimits.minSat}");
   print("Maximum amount, in sats: ${currentLimits.maxSat}");
   // ANCHOR_END: get-current-reverse-swap-limits
@@ -20,7 +20,7 @@ Future<PrepareOnchainPaymentResponse> preparePayOnchain({
     amountType: SwapAmountType.Send,
     claimTxFeerate: satPerVbyte,
   );
-  PrepareOnchainPaymentResponse prepareRes = await BreezSDK().prepareOnchainPayment(req: req);
+  PrepareOnchainPaymentResponse prepareRes = await breezSDK.prepareOnchainPayment(req: req);
   print("Sender amount: ${prepareRes.senderAmountSat} sats");
   print("Recipient amount: ${prepareRes.recipientAmountSat} sats");
   print("Total fees: ${prepareRes.totalFees} sats");
@@ -37,14 +37,14 @@ Future<PayOnchainResponse> startReverseSwap({
     recipientAddress: onchainRecipientAddress,
     prepareRes: prepareRes,
   );
-  PayOnchainResponse res = await BreezSDK().payOnchain(req: req);
+  PayOnchainResponse res = await breezSDK.payOnchain(req: req);
   // ANCHOR_END: start-reverse-swap
   return res;
 }
 
 Future<List<ReverseSwapInfo>> checkReverseSwapStatus() async {
   // ANCHOR: check-reverse-swaps-status
-  List<ReverseSwapInfo> inProgOnchainPaymentList = await BreezSDK().inProgressOnchainPayments();
+  List<ReverseSwapInfo> inProgOnchainPaymentList = await breezSDK.inProgressOnchainPayments();
   for (var inProgOnchainPayment in inProgOnchainPaymentList) {
     print("Onchain payment ${inProgOnchainPayment.id} in progress, status is ${inProgOnchainPayment.status.name}");
   }

--- a/snippets/dart_snippets/lib/receive_onchain.dart
+++ b/snippets/dart_snippets/lib/receive_onchain.dart
@@ -1,10 +1,10 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<SwapInfo> generateReceiveOnchainAddress() async {
   // ANCHOR: generate-receive-onchain-address
   ReceiveOnchainRequest req = const ReceiveOnchainRequest();
-  SwapInfo swapInfo = await BreezSDK().receiveOnchain(req: req);
+  SwapInfo swapInfo = await breezSDK.receiveOnchain(req: req);
 
   // Send your funds to the below bitcoin address
   String address = swapInfo.bitcoinAddress;
@@ -17,7 +17,7 @@ Future<SwapInfo> generateReceiveOnchainAddress() async {
 
 Future<SwapInfo?> getInProgressSwap() async {
   // ANCHOR: in-progress-swap
-  SwapInfo? swapInfo = await BreezSDK().inProgressSwap();
+  SwapInfo? swapInfo = await breezSDK.inProgressSwap();
   print(swapInfo);
   // ANCHOR_END: in-progress-swap
   return swapInfo;
@@ -25,7 +25,7 @@ Future<SwapInfo?> getInProgressSwap() async {
 
 Future<List<SwapInfo>> listRefundables() async {
   // ANCHOR: list-refundables
-  List<SwapInfo> refundables = await BreezSDK().listRefundables();
+  List<SwapInfo> refundables = await breezSDK.listRefundables();
   for (var refundable in refundables) {
     print(refundable.bitcoinAddress);
   }
@@ -44,7 +44,7 @@ Future<RefundResponse> executeRefund({
     toAddress: toAddress,
     satPerVbyte: satPerVbyte,
   );
-  RefundResponse resp = await BreezSDK().refund(req: req);
+  RefundResponse resp = await breezSDK.refund(req: req);
   print(resp.refundTxId);
   // ANCHOR_END: execute-refund
   return resp;
@@ -56,7 +56,7 @@ Future<OpenChannelFeeResponse> getChannelOpeningFees({
 }) async {
   // ANCHOR: get-channel-opening-fees
   OpenChannelFeeRequest req = OpenChannelFeeRequest(amountMsat: amountMsat, expiry: expiry);
-  OpenChannelFeeResponse resp = await BreezSDK().openChannelFee(req: req);
+  OpenChannelFeeResponse resp = await breezSDK.openChannelFee(req: req);
   print(resp.feeMsat);
   // ANCHOR_END: get-channel-opening-fees
   return resp;
@@ -64,6 +64,6 @@ Future<OpenChannelFeeResponse> getChannelOpeningFees({
 
 Future rescanSwaps() async {
   // ANCHOR: rescan-swaps
-  await BreezSDK().rescanSwaps();  
+  await breezSDK.rescanSwaps();  
   // ANCHOR_END: rescan-swaps  
 }

--- a/snippets/dart_snippets/lib/receive_payment.dart
+++ b/snippets/dart_snippets/lib/receive_payment.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<ReceivePaymentResponse> receivePayment() async {
@@ -7,7 +7,7 @@ Future<ReceivePaymentResponse> receivePayment() async {
     amountMsat: 3000000,
     description: "Invoice for 3000 sats",
   );
-  ReceivePaymentResponse receivePaymentResponse = await BreezSDK().receivePayment(req: req);
+  ReceivePaymentResponse receivePaymentResponse = await breezSDK.receivePayment(req: req);
 
   print(receivePaymentResponse.lnInvoice);
   // ANCHOR_END: receive-payment

--- a/snippets/dart_snippets/lib/sdk_instance.dart
+++ b/snippets/dart_snippets/lib/sdk_instance.dart
@@ -1,0 +1,3 @@
+import 'package:breez_sdk/breez_sdk.dart';
+
+BreezSDK breezSDK = BreezSDK();

--- a/snippets/dart_snippets/lib/send_payment.dart
+++ b/snippets/dart_snippets/lib/send_payment.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<SendPaymentResponse> sendPayment({required String bolt11}) async {
@@ -8,7 +8,7 @@ Future<SendPaymentResponse> sendPayment({required String bolt11}) async {
   int optionalAmountMsat = 3000000;
   String optionalLabel = "<label>";
   SendPaymentRequest req = SendPaymentRequest(bolt11: bolt11, amountMsat: optionalAmountMsat, label: optionalLabel);
-  SendPaymentResponse resp = await BreezSDK().sendPayment(req: req);
+  SendPaymentResponse resp = await breezSDK.sendPayment(req: req);
   // ANCHOR_END: send-payment
   return resp;
 }

--- a/snippets/dart_snippets/lib/send_spontaneous_payment.dart
+++ b/snippets/dart_snippets/lib/send_spontaneous_payment.dart
@@ -1,4 +1,4 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'dart:convert';
 
@@ -13,7 +13,7 @@ Future<SendPaymentResponse> sendSpontaneousPayment({
     nodeId: nodeId,
     label: optionalLabel,
   );
-  SendPaymentResponse resp = await BreezSDK().sendSpontaneousPayment(req: req);
+  SendPaymentResponse resp = await breezSDK.sendSpontaneousPayment(req: req);
   // ANCHOR_END: send-spontaneous-payment
   return resp;
 }
@@ -33,7 +33,7 @@ Future<SendPaymentResponse> sendSpontaneousPaymentWithTlvs({
     nodeId: nodeId,
     extraTlvs: optionalExtraTlvs,
   );
-  SendPaymentResponse resp = await BreezSDK().sendSpontaneousPayment(req: req);
+  SendPaymentResponse resp = await breezSDK.sendSpontaneousPayment(req: req);
   // ANCHOR_END: send-spontaneous-payment-with-tlvs
   return resp;
 }

--- a/snippets/dart_snippets/lib/service_status.dart
+++ b/snippets/dart_snippets/lib/service_status.dart
@@ -1,9 +1,9 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<void> healthCheckStatus() async {
   // ANCHOR: health-check-status
-  ServiceHealthCheckResponse healthCheck = await BreezSDK().serviceHealthCheck(apiKey: "<api key>");
+  ServiceHealthCheckResponse healthCheck = await breezSDK.serviceHealthCheck(apiKey: "<api key>");
   print("Current service status is: ${healthCheck.status}");
   // ANCHOR_END: health-check-status
 }
@@ -15,6 +15,6 @@ Future<void> reportPaymentFailure({required String paymentHash}) async {
       paymentHash: paymentHash,
     ),
   );
-  await BreezSDK().reportIssue(req: req);
+  await breezSDK.reportIssue(req: req);
   // ANCHOR_END: report-payment-failure
 }

--- a/snippets/dart_snippets/lib/static_channel_backup.dart
+++ b/snippets/dart_snippets/lib/static_channel_backup.dart
@@ -1,10 +1,10 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 
 Future<StaticBackupResponse> retrieveBackupFiles({required String workingDir}) async {
   // ANCHOR: static-channel-backup
   StaticBackupRequest req = StaticBackupRequest(workingDir: workingDir);
-  StaticBackupResponse resp = await BreezSDK().staticBackup(req: req);
+  StaticBackupResponse resp = await breezSDK.staticBackup(req: req);
   // ANCHOR_END: static-channel-backup
   return resp;
 }

--- a/snippets/dart_snippets/lib/webhook.dart
+++ b/snippets/dart_snippets/lib/webhook.dart
@@ -1,13 +1,13 @@
-import 'package:breez_sdk/breez_sdk.dart';
+import 'package:dart_snippets/sdk_instance.dart';
 
 Future<void> registerWebhook() async {
   // ANCHOR: register-webook
-  await BreezSDK().registerWebhook(webhookUrl: "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>");  
+  await breezSDK.registerWebhook(webhookUrl: "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>");
   // ANCHOR_END: register-webook
 }
 
 Future<void> unregisterWebhook() async {
   // ANCHOR: unregister-webook
-  await BreezSDK().unregisterWebhook(webhookUrl: "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>");  
+  await breezSDK.unregisterWebhook(webhookUrl: "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>");
   // ANCHOR_END: unregister-webook
 }

--- a/snippets/dart_snippets/pubspec.lock
+++ b/snippets/dart_snippets/pubspec.lock
@@ -5,34 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "64.0.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.4.1"
   archive:
     dependency: transitive
     description:
       name: archive
-      sha256: "7b875fd4a20b165a3084bd2d210439b22ebc653f21cea4842729c0c30c82596b"
+      sha256: "6bd38d335f0954f5fad9c79e614604fbf03a0e5b975923dd001b6ea965ef5b4b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.9"
+    version: "3.6.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -116,10 +116,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: ac86d3abab0f165e4b8f561280ff4e066bceaac83c424dd19f1ae2c2fcd12ca9
+      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.1"
+    version: "1.8.0"
   crypto:
     dependency: transitive
     description:
@@ -132,18 +132,18 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.6"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -152,6 +152,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: transitive
     description: flutter
@@ -161,18 +169,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_rust_bridge
-      sha256: ff90d5ddd0cda6d94ed048cc9c4a4d993d1a4bb11605d60a1282fc1bbf173c77
+      sha256: "02720226035257ad0b571c1256f43df3e1556a499f6bcb004849a0faaa0e87f0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.80.1"
+    version: "1.82.6"
   freezed:
     dependency: transitive
     description:
       name: freezed
-      sha256: "21bf2825311de65501d22e563e3d7605dff57fb5e6da982db785ae5372ff018a"
+      sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.5.2"
   freezed_annotation:
     dependency: transitive
     description:
@@ -185,10 +193,10 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -201,10 +209,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: d4872660c46d929f6b8a9ef4e7a7eff7e49bbf0c4ec3f385ee32df5119175139
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -241,10 +249,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   lints:
     dependency: "direct dev"
     description:
@@ -265,34 +273,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   node_preamble:
     dependency: transitive
     description:
@@ -313,26 +321,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: eeb2d1428ee7f4170e2bd498827296a18d4e7fc462b71727d111c0ac7707cfa6
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
-  pointycastle:
-    dependency: transitive
-    description:
-      name: pointycastle
-      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.3"
+    version: "6.0.2"
   pool:
     dependency: transitive
     description:
@@ -353,18 +353,18 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   puppeteer:
     dependency: transitive
     description:
       name: puppeteer
-      sha256: eedeaae6ec5d2e54f9ae22ab4d6b3dda2e8791c356cc783046d06c287ffe11d8
+      sha256: c45c51b4ad8d70acdffeb1cfb9d16b60a7eaab7bfef314dd5b02c3607269b556
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.0"
+    version: "3.11.0"
   rxdart:
     dependency: transitive
     description:
@@ -414,10 +414,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -442,6 +442,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -478,26 +486,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.0"
   tuple:
     dependency: transitive
     description:
@@ -518,10 +526,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -534,10 +542,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.2"
   watcher:
     dependency: transitive
     description:
@@ -550,18 +558,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.5"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -579,5 +587,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.10.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"


### PR DESCRIPTION
This PR addresses 
- #145 

#### Changelist:
- Use a single instance of `BreezSDK` on Dart snippets
  - Add documentation that recommends using single instance of `BreezSDK` and possible options on how.
  - Add documentation on how to use `initialize()` in light of recent SDK stream management changes.