### PR TITLE
Add notes about reverse swap notifications

### DIFF
--- a/src/guide/pay_onchain.md
+++ b/src/guide/pay_onchain.md
@@ -312,3 +312,17 @@ change from pending to settled.
 
 If however something goes wrong at any point in the process, the initial HODL payment will be cancelled and the funds in
 your Breez SDK wallet will be unlocked.
+<div class="warning">
+<h4>Developer note</h4>
+Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive a transaction confirmation notification to claim the swap in the background.
+</div>
+
+
+## Notifications
+
+Enabling [mobile notifications](/notifications/getting_started.md) will register your app for swap notifications.
+
+This means that, when the user performs a swap-out (send onchain), the app will
+
+- automatically claim the swap in the background when the onchain transaction is confirmed, even if the app is closed
+- display an OS notification, informing the user of the received funds

--- a/src/guide/pay_onchain.md
+++ b/src/guide/pay_onchain.md
@@ -314,7 +314,7 @@ If however something goes wrong at any point in the process, the initial HODL pa
 your Breez SDK wallet will be unlocked.
 <div class="warning">
 <h4>Developer note</h4>
-Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive a transaction confirmation notification to claim the swap in the background.
+Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook, the application can receive a transaction confirmation notification to claim the swap in the background.
 </div>
 
 

--- a/src/guide/payment_notification.md
+++ b/src/guide/payment_notification.md
@@ -43,7 +43,7 @@ The `payment_received` notification type will be received by the webhook in the 
 
 #### Confirming a swap
 
-When receiving a payment via a onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin when receiving this notification from the NDS will connect to the Breez SDK and redeem the swap. 
+When sending or receiving a payment via a onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin when receiving this notification from the NDS will connect to the Breez SDK and claim or redeem the swap. 
 
 The `address_txs_confirmed` notification type will be received by the webhook in the following format:
 ```json

--- a/src/guide/payment_notification.md
+++ b/src/guide/payment_notification.md
@@ -43,7 +43,7 @@ The `payment_received` notification type will be received by the webhook in the 
 
 #### Confirming a swap
 
-When sending or receiving a payment via a onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin when receiving this notification from the NDS will connect to the Breez SDK and claim or redeem the swap. 
+When sending or receiving a payment via an onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin, upon receiving this notification from the NDS, will connect to the Breez SDK and claim or redeem the swap.
 
 The `address_txs_confirmed` notification type will be received by the webhook in the following format:
 ```json

--- a/src/guide/receive_onchain.md
+++ b/src/guide/receive_onchain.md
@@ -163,7 +163,7 @@ Consider implementing the <a href="/notifications/getting_started.md">Notificati
 
 ## Notifications
 
-Enabling [mobile notifications](payment_notification.md) will register your app for swap notifications.
+Enabling [mobile notifications](/notifications/getting_started.md) will register your app for swap notifications.
 
 This means that, when the user performs a swap-in (receive onchain), the app will
 

--- a/src/notifications/custom_messages.md
+++ b/src/notifications/custom_messages.md
@@ -33,7 +33,7 @@ class NotificationService: SDKNotificationService {
         self.logger.log(tag: TAG, line: "\(notificationType) data string: \(payload)", level: "INFO")
         switch(notificationType) {
         case Constants.MESSAGE_TYPE_ADDRESS_TXS_CONFIRMED:
-            return RedeemSwapTask(payload: payload, logger: self.logger, contentHandler: contentHandler, bestAttemptContent: bestAttemptContent)
+            return ConfirmTransactionTask(payload: payload, logger: self.logger, contentHandler: contentHandler, bestAttemptContent: bestAttemptContent)
         case Constants.MESSAGE_TYPE_LNURL_PAY_INFO:
             return LnurlPayInfoTask(payload: payload, logger: self.logger, config: self.config, contentHandler: contentHandler, bestAttemptContent: bestAttemptContent)
         case Constants.MESSAGE_TYPE_LNURL_PAY_INVOICE:

--- a/src/notifications/getting_started.md
+++ b/src/notifications/getting_started.md
@@ -43,7 +43,7 @@ The `payment_received` notification type will be received by the webhook in the 
 
 #### Confirming a swap
 
-When receiving a payment via a onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin when receiving this notification from the NDS will connect to the Breez SDK and redeem the swap. 
+When sending or receiving a payment via a onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin when receiving this notification from the NDS will connect to the Breez SDK and claim or redeem the swap. 
 
 The `address_txs_confirmed` notification type will be received by the webhook in the following format:
 ```json

--- a/src/notifications/getting_started.md
+++ b/src/notifications/getting_started.md
@@ -43,7 +43,7 @@ The `payment_received` notification type will be received by the webhook in the 
 
 #### Confirming a swap
 
-When sending or receiving a payment via a onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin when receiving this notification from the NDS will connect to the Breez SDK and claim or redeem the swap. 
+When sending or receiving a payment via an onchain address, the swap address needs to be monitored until the funds are confirmed onchain before the swap is executed. A chain service is used to monitor the address for confirmed funds. Once funds are confirmed, the chain service calls the registered webhook with the address. The Notification Plugin, upon receiving this notification from the NDS, will connect to the Breez SDK and claim or redeem the swap.
 
 The `address_txs_confirmed` notification type will be received by the webhook in the following format:
 ```json


### PR DESCRIPTION
Reverse swaps can now be handled by the Notification Plugin, add notes to send onchain docs

See PR https://github.com/breez/breez-sdk/pull/953