### PR TITLE
Fix NDS example URL

### DIFF
--- a/snippets/csharp/Webhook.cs
+++ b/snippets/csharp/Webhook.cs
@@ -7,7 +7,7 @@ public class ServiceStatusSnippets
         // ANCHOR: register-webook
         try
         {
-            var url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
+            var url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
             sdk.RegisterWebhook(url);
         }
         catch (Exception)
@@ -22,7 +22,7 @@ public class ServiceStatusSnippets
         // ANCHOR: unregister-webook
         try
         {
-            var url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
+            var url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
             sdk.UnregisterWebhook(url);
         }
         catch (Exception)

--- a/snippets/dart_snippets/lib/webhook.dart
+++ b/snippets/dart_snippets/lib/webhook.dart
@@ -2,14 +2,14 @@ import 'package:dart_snippets/sdk_instance.dart';
 
 Future<void> registerWebhook() async {
   // ANCHOR: register-webook
-  String url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
+  String url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
   await breezSDK.registerWebhook(webhookUrl: url);
   // ANCHOR_END: register-webook
 }
 
 Future<void> unregisterWebhook() async {
   // ANCHOR: unregister-webook
-  String url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
+  String url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>";
   await breezSDK.unregisterWebhook(webhookUrl: url);
   // ANCHOR_END: unregister-webook
 }

--- a/snippets/go/webhook.go
+++ b/snippets/go/webhook.go
@@ -6,7 +6,7 @@ import (
 
 func RegisterWebhook() error {
 	// ANCHOR: register-webook
-	url := "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+	url := "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
 	err := sdk.RegisterWebhook(url)
 	if err != nil {
 		log.Printf("Webhook register failed: %v", err)
@@ -18,7 +18,7 @@ func RegisterWebhook() error {
 
 func UnregisterWebhook() error {
 	// ANCHOR: unregister-webook
-	url := "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+	url := "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
 	err := sdk.UnregisterWebhook(url)
 	if err != nil {
 		log.Printf("Webhook unregister failed: %v", err)

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Webhook.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Webhook.kt
@@ -5,7 +5,7 @@ class Webhooks {
     fun registerWebhook(sdk: BlockingBreezServices) {
         // ANCHOR: register-webook
         try {
-            val url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+            val url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
             sdk.registerWebhook(url)
         } catch (e: Exception) {
             // Handle error
@@ -16,7 +16,7 @@ class Webhooks {
     fun unregisterWebhook(sdk: BlockingBreezServices) {
         // ANCHOR: unregister-webook
         try {
-            val url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+            val url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
             sdk.unregisterWebhook(url)
         } catch (e: Exception) {
             // Handle error

--- a/snippets/python/src/webhook.py
+++ b/snippets/python/src/webhook.py
@@ -3,7 +3,7 @@ import breez_sdk
 def register_webhook(sdk_services):
     try:
         # ANCHOR: register-webook
-        url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+        url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
         sdk_services.register_webhook(webhook_url=url)
         # ANCHOR_END: register-webook
     except Exception as error:
@@ -13,7 +13,7 @@ def register_webhook(sdk_services):
 def unregister_webhook(sdk_services):
     try:
         # ANCHOR: unregister-webook
-        url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+        url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
         sdk_services.unregister_webhook(webhook_url=url)
         # ANCHOR_END: unregister-webook
     except Exception as error:

--- a/snippets/react-native/webhook.ts
+++ b/snippets/react-native/webhook.ts
@@ -3,7 +3,7 @@ import { registerWebhook, unregisterWebhook } from '@breeztech/react-native-bree
 const _registerWebhook = async () => {
   // ANCHOR: register-webook
   try {
-    const url = 'https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>'
+    const url = 'https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>'
     await registerWebhook(url)
   } catch (err) {
     console.error(err)
@@ -14,7 +14,7 @@ const _registerWebhook = async () => {
 const _unregisterWebhook = async () => {
   // ANCHOR: unregister-webook
   try {
-    const url = 'https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>'
+    const url = 'https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>'
     await unregisterWebhook(url)
   } catch (err) {
     console.error(err)

--- a/snippets/rust/src/webhook.rs
+++ b/snippets/rust/src/webhook.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 async fn register_webhook(sdk: Arc<BreezServices>) -> Result<()> {
     // ANCHOR: register-webook
     let url =
-        "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>".to_string();
+        "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>".to_string();
     sdk.register_webhook(url).await?;
     // ANCHOR_END: register-webook
 
@@ -15,7 +15,7 @@ async fn register_webhook(sdk: Arc<BreezServices>) -> Result<()> {
 async fn unregister_webhook(sdk: Arc<BreezServices>) -> Result<()> {
     // ANCHOR: unregister-webook
     let url =
-        "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>".to_string();
+        "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>".to_string();
     sdk.unregister_webhook(url).await?;
     // ANCHOR_END: unregister-webook
 

--- a/snippets/swift/BreezSDKExamples/Sources/Webhook.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/Webhook.swift
@@ -9,14 +9,14 @@ import BreezSDK
 
 func registerWebhook(sdk: BlockingBreezServices) throws {
     // ANCHOR: register-webook
-    let url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+    let url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
     try sdk.registerWebhook(webhookUrl: url)  
     // ANCHOR_END: register-webook
 }
 
 func unregisterWebhook(sdk: BlockingBreezServices) throws {
     // ANCHOR: unregister-webook
-    let url = "https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
+    let url = "https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=<PUSH_TOKEN>"
     try sdk.unregisterWebhook(webhookUrl: url)  
     // ANCHOR_END: unregister-webook
 }

--- a/src/notifications/setup_nds.md
+++ b/src/notifications/setup_nds.md
@@ -13,14 +13,10 @@ Receiving push notifications involves using an Notification Delivery Service (ND
 
 The need to run your own NDS is because it's configured to send push notifications to your application users and therefore should be configured with the required keys and certificates. You can use our [reference NDS implementation](https://github.com/breez/notify) as a starting point or as is. Our implementation of the NDS expects URLs in the following format:
 ```
-https://your-nds-service.com/notify?platform=<ios|android>&token=<PUSH_TOKEN>
+https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=[PUSH_TOKEN]
 ```
-  
 
-
-This is the same format used when [registering a webhook](using_webhooks.md) in the Breez SDK, replacing the `<PUSH_TOKEN>` with the mobile push token. Once the NDS has received such request it will send a push notification to the corresponding device.
+This is the same format used when [registering a webhook](using_webhooks.md) in the Breez SDK, replacing the `PUSH_TOKEN` with the mobile push token. Once the NDS has received such request it will send a push notification to the corresponding device.
 
 ## Mobile push token
-Ensure that your mobile application is set up to receive push notifications and can generate a push token. This token uniquely identifies the device for push notifications.
-* For iOS, use [Apple Push Notification Service (APNs)](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns) to get the token.
-* For Android, use [Firebase Cloud Messaging (FCM)](https://firebase.google.com/docs/cloud-messaging/manage-tokens) to obtain the token.
+Ensure that your mobile application is set up to receive push notifications and can generate a push token. This token uniquely identifies the device for push notifications. Our [reference NDS implementation](https://github.com/breez/notify) uses [Firebase Cloud Messaging (FCM)](https://firebase.google.com/docs/cloud-messaging/manage-tokens) to deliver push notifications, so your application should use Firebase to obtain the `PUSH_TOKEN`.


### PR DESCRIPTION
This PR:
- Fixes the NDS webhook URLs for the reference implementation
- Clarifies the FCM token should be used for both iOS and Android